### PR TITLE
Timestamp must be before the close for the market to be open

### DIFF
--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -201,7 +201,7 @@ class MarketCalendar(six.with_metaclass(ABCMeta)):
     @staticmethod
     def open_at_time(schedule, timestamp):
         """
-        To determine if a given timesamp is during an open time for the market.
+        To determine if a given timestamp is during an open time for the market.
         
         :param schedule: schedule DataFrame
         :param timestamp: the timestamp to check for
@@ -209,7 +209,7 @@ class MarketCalendar(six.with_metaclass(ABCMeta)):
         """
         date = timestamp.date()
         if date in schedule.index:
-            return schedule.loc[date, 'market_open'] <= timestamp <= schedule.loc[date, 'market_close']
+            return schedule.loc[date, 'market_open'] <= timestamp < schedule.loc[date, 'market_close']
         else:
             return False
 

--- a/tests/test_eurex_calendar.py
+++ b/tests/test_eurex_calendar.py
@@ -5,7 +5,7 @@ from pandas_market_calendars.exchange_calendar_eurex import EUREXExchangeCalenda
 
 
 def test_time_zone():
-    assert EUREXExchangeCalendar().tz == pytz.timezone('Europe/London')
+    assert EUREXExchangeCalendar().tz == pytz.timezone('Europe/Berlin')
     assert EUREXExchangeCalendar().name == 'EUREX'
 
 

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -190,9 +190,9 @@ def test_early_close_independence_day_thursday():
     nyse = NYSEExchangeCalendar()
     schedule = nyse.schedule('2001-01-01', '2016-12-31')
 
-    wednesday_before = pd.Timestamp('7/3/2002 3:00PM', tz='EST')
-    friday_after_open = pd.Timestamp('7/5/2002 11:00AM', tz='EST')
-    friday_after = pd.Timestamp('7/5/2002 3:00PM', tz='EST')
+    wednesday_before = pd.Timestamp('7/3/2002 3:00PM', tz='America/New_York')
+    friday_after_open = pd.Timestamp('7/5/2002 11:00AM', tz='America/New_York')
+    friday_after = pd.Timestamp('7/5/2002 3:00PM', tz='America/New_York')
     assert nyse.open_at_time(schedule, wednesday_before) is True
     assert nyse.open_at_time(schedule, friday_after_open) is True
     assert nyse.open_at_time(schedule, friday_after) is False
@@ -204,9 +204,9 @@ def test_early_close_independence_day_thursday():
     # 14 15 16 17 18 19 20
     # 21 22 23 24 25 26 27
     # 28 29 30 31
-    wednesday_before = pd.Timestamp('7/3/2013 3:00PM', tz='EST')
-    friday_after_open = pd.Timestamp('7/5/2013 11:00AM', tz='EST')
-    friday_after = pd.Timestamp('7/5/2013 3:00PM', tz='EST')
+    wednesday_before = pd.Timestamp('7/3/2013 3:00PM', tz='America/New_York')
+    friday_after_open = pd.Timestamp('7/5/2013 11:00AM', tz='America/New_York')
+    friday_after = pd.Timestamp('7/5/2013 3:00PM', tz='America/New_York')
     assert nyse.open_at_time(schedule, wednesday_before) is False
     assert nyse.open_at_time(schedule, friday_after_open) is True
     assert nyse.open_at_time(schedule, friday_after) is True


### PR DESCRIPTION
Whereas the timestamp being equal to the open means the market is indeed open, if the timestamp is equal to the close it means the market is closed.  This extremely minor change fixes that, in addition to fixing a typo.  Let me know if you have any questions or disagree.  Thanks!