### PR TITLE
Add calendar for the JPX stock exchange

### DIFF
--- a/pandas_market_calendars/calendar_utils.py
+++ b/pandas_market_calendars/calendar_utils.py
@@ -11,6 +11,7 @@ from pandas_market_calendars.exchange_calendar_bmf import BMFExchangeCalendar
 from pandas_market_calendars.exchange_calendar_lse import LSEExchangeCalendar
 from pandas_market_calendars.exchange_calendar_tsx import TSXExchangeCalendar
 from pandas_market_calendars.exchange_calendar_eurex import EUREXExchangeCalendar
+from pandas_market_calendars.exchange_calendar_jpx import JPXExchangeCalendar
 
 _calendars = {
     'NYSE': NYSEExchangeCalendar,
@@ -20,7 +21,8 @@ _calendars = {
     'BMF': BMFExchangeCalendar,
     'LSE': LSEExchangeCalendar,
     'TSX': TSXExchangeCalendar,
-    'EUREX': EUREXExchangeCalendar
+    'EUREX': EUREXExchangeCalendar,
+    'JPX': JPXExchangeCalendar
 }
 
 _aliases = {

--- a/pandas_market_calendars/exchange_calendar_jpx.py
+++ b/pandas_market_calendars/exchange_calendar_jpx.py
@@ -1,0 +1,155 @@
+from datetime import time
+
+from dateutil.relativedelta import MO
+from pandas import DateOffset
+from pandas.tseries.holiday import Holiday, weekend_to_monday
+from pytz import timezone
+
+from pandas.tseries.holiday import AbstractHolidayCalendar
+from pandas_market_calendars.us_holidays import USNewYearsDay
+
+from pandas_market_calendars import MarketCalendar
+
+
+class JPXExchangeCalendar(MarketCalendar):
+    """
+    Exchange calendar for JPX
+
+    Open Time: 9:31 AM, Asia/Tokyo
+    LUNCH BREAK :facepalm: : 11:30 AM - 12:30 PM Asia/Tokyo
+    Close Time: 4:00 PM, Asia/Tokyo
+    """
+
+    regular_early_close = time(13)
+    lunch_start = time(11, 30)
+    lunch_end = time(12, 30)
+
+    @property
+    def name(self):
+        return "JPX"
+
+    @property
+    def tz(self):
+        return timezone('Asia/Tokyo')
+
+    @property
+    def open_time_default(self):
+        return time(9, 0)
+
+    @property
+    def close_time_default(self):
+        return time(15)
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            USNewYearsDay,
+            Holiday(
+                name="New Year's Day",
+                month=1,
+                day=2,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="New Year's Day",
+                month=1,
+                day=3,
+                observance=weekend_to_monday,
+            ),
+            Holiday(  # second monday of january
+                name="Coming of Age Day",
+                month=1,
+                day=1,
+                offset=DateOffset(weekday=MO(2)),
+            ),
+            Holiday(
+                name="National foundation day",
+                month=2,
+                day=11,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Vernal Equinox",
+                month=3,
+                day=20,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Showa day",
+                month=4,
+                day=29,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Constitution memorial day",
+                month=5,
+                day=3,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Greenery day",
+                month=5,
+                day=4,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Children's day",
+                month=5,
+                day=5,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Marine day",
+                month=7,
+                day=1,
+                offset=DateOffset(weekday=MO(3)),
+            ),
+            Holiday(
+                name="Mountain day",
+                month=8,
+                day=11,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Respect for the aged day",
+                month=9,
+                day=1,
+                offset=DateOffset(weekday=MO(3)),
+            ),
+            Holiday(
+                name="Autumnal equinox",
+                month=9,
+                day=23,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Health and sports day",
+                month=10,
+                day=1,
+                offset=DateOffset(weekday=MO(2)),
+            ),
+            Holiday(
+                name="Culture day",
+                month=11,
+                day=3,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Labor Thanksgiving Day",
+                month=11,
+                day=23,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Emperor's Birthday",
+                month=12,
+                day=23,
+                observance=weekend_to_monday,
+            ),
+            Holiday(
+                name="Before New Year's Day",
+                month=12,
+                day=31,
+                observance=weekend_to_monday,
+            ),
+        ])

--- a/pandas_market_calendars/exchange_calendar_jpx.py
+++ b/pandas_market_calendars/exchange_calendar_jpx.py
@@ -2,7 +2,7 @@ from datetime import time
 
 from dateutil.relativedelta import MO
 from pandas import DateOffset
-from pandas.tseries.holiday import Holiday, weekend_to_monday
+from pandas.tseries.holiday import Holiday, sunday_to_monday
 from pytz import timezone
 
 from pandas.tseries.holiday import AbstractHolidayCalendar
@@ -48,13 +48,13 @@ class JPXExchangeCalendar(MarketCalendar):
                 name="New Year's Day",
                 month=1,
                 day=2,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="New Year's Day",
                 month=1,
                 day=3,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(  # second monday of january
                 name="Coming of Age Day",
@@ -66,37 +66,37 @@ class JPXExchangeCalendar(MarketCalendar):
                 name="National foundation day",
                 month=2,
                 day=11,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Vernal Equinox",
                 month=3,
                 day=20,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Showa day",
                 month=4,
                 day=29,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Constitution memorial day",
                 month=5,
                 day=3,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Greenery day",
                 month=5,
                 day=4,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Children's day",
                 month=5,
                 day=5,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Marine day",
@@ -108,7 +108,7 @@ class JPXExchangeCalendar(MarketCalendar):
                 name="Mountain day",
                 month=8,
                 day=11,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Respect for the aged day",
@@ -120,7 +120,7 @@ class JPXExchangeCalendar(MarketCalendar):
                 name="Autumnal equinox",
                 month=9,
                 day=23,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Health and sports day",
@@ -132,25 +132,25 @@ class JPXExchangeCalendar(MarketCalendar):
                 name="Culture day",
                 month=11,
                 day=3,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Labor Thanksgiving Day",
                 month=11,
                 day=23,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Emperor's Birthday",
                 month=12,
                 day=23,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
             Holiday(
                 name="Before New Year's Day",
                 month=12,
                 day=31,
-                observance=weekend_to_monday,
+                observance=sunday_to_monday,
             ),
         ])
 

--- a/pandas_market_calendars/exchange_calendar_jpx.py
+++ b/pandas_market_calendars/exchange_calendar_jpx.py
@@ -153,3 +153,9 @@ class JPXExchangeCalendar(MarketCalendar):
                 observance=weekend_to_monday,
             ),
         ])
+
+    @staticmethod
+    def open_at_time(schedule, timestamp, include_close=False):
+        if JPXExchangeCalendar.lunch_start < timestamp.time() < JPXExchangeCalendar.lunch_end:
+            return False
+        return MarketCalendar.open_at_time(schedule, timestamp, include_close)

--- a/tests/test_jpx_calendar.py
+++ b/tests/test_jpx_calendar.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytz
+from pandas_market_calendars.exchange_calendar_jpx import JPXExchangeCalendar
+
+
+def test_time_zone():
+    assert JPXExchangeCalendar().tz == pytz.timezone('Asia/Tokyo')
+    assert JPXExchangeCalendar().name == 'JPX'
+
+
+def test_2017_holidays():
+    jpx_calendar = JPXExchangeCalendar()
+
+    # holidays we expect
+    holidays_2017 = [
+        pd.Timestamp("2017-01-01", tz='UTC'),
+        pd.Timestamp("2017-01-02", tz='UTC'),
+        pd.Timestamp("2017-01-03", tz='UTC'),
+        pd.Timestamp("2017-01-09", tz='UTC'),
+        pd.Timestamp("2017-02-11", tz='UTC'),
+        pd.Timestamp("2017-03-20", tz='UTC'),
+        pd.Timestamp("2017-04-29", tz='UTC'),
+        pd.Timestamp("2017-05-03", tz='UTC'),
+        pd.Timestamp("2017-05-04", tz='UTC'),
+        pd.Timestamp("2017-05-05", tz='UTC'),
+        pd.Timestamp("2017-07-17", tz='UTC'),
+        pd.Timestamp("2017-08-11", tz='UTC'),
+        pd.Timestamp("2017-09-23", tz='UTC'),
+        pd.Timestamp("2017-10-09", tz='UTC'),
+        pd.Timestamp("2017-11-03", tz='UTC'),
+        pd.Timestamp("2017-11-23", tz='UTC'),
+        pd.Timestamp("2017-12-23", tz='UTC'),
+        pd.Timestamp("2017-12-31", tz='UTC'),
+    ]
+
+    for session_label in holidays_2017:
+        assert session_label not in jpx_calendar.valid_days('2017-01-01', '2017-12-31')

--- a/tests/test_jpx_calendar.py
+++ b/tests/test_jpx_calendar.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pandas as pd
 import pytz
 from pandas_market_calendars.exchange_calendar_jpx import JPXExchangeCalendar
@@ -35,3 +37,21 @@ def test_2017_holidays():
 
     for session_label in holidays_2017:
         assert session_label not in jpx_calendar.valid_days('2017-01-01', '2017-12-31')
+
+
+def test_jpx_closes_at_lunch():
+    jpx_calendar = JPXExchangeCalendar()
+    jpx_schedule = jpx_calendar.schedule(
+        start_date=datetime.datetime(2015, 1, 14, tzinfo=pytz.timezone('Asia/Tokyo')),
+        end_date=datetime.datetime(2015, 1, 16, tzinfo=pytz.timezone('Asia/Tokyo'))
+    )
+
+    assert JPXExchangeCalendar.open_at_time(
+        schedule=jpx_schedule,
+        timestamp=datetime.datetime(2015, 1, 14, 11, 0, tzinfo=pytz.timezone('Asia/Tokyo'))
+    )
+
+    assert not JPXExchangeCalendar.open_at_time(
+            schedule=jpx_schedule,
+            timestamp=datetime.datetime(2015, 1, 14, 12, 0, tzinfo=pytz.timezone('Asia/Tokyo'))
+        )


### PR DESCRIPTION
Takes into account Japanese public holidays and lunch time closures.