### PR TITLE
NYSE was closed 1985-09-27 for Hurricane Gloria.

### DIFF
--- a/pandas_market_calendars/exchange_calendar_nyse.py
+++ b/pandas_market_calendars/exchange_calendar_nyse.py
@@ -37,6 +37,7 @@ from pandas_market_calendars.us_holidays import (
     USBlackFridayBefore1993,
     USBlackFridayInOrAfter1993,
     September11Closings,
+    HurricaneGloriaClosings,
     HurricaneSandyClosings,
     USNationalDaysofMourning,
     ChristmasEveBefore1993,
@@ -81,11 +82,12 @@ class NYSEExchangeCalendar(MarketCalendar):
     From 1993 onward, it has been 1:00 PM.
 
     Additional Irregularities:
-    - Closed from 9/11/2001 to 9/16/2001 due to terrorist attacks in NYC.
-    - Closed on 10/29/2012 and 10/30/2012 due to Hurricane Sandy.
+    - Closed on 9/27/1985 due to Hurricane Gloria.
     - Closed on 4/27/1994 due to Richard Nixon's death.
+    - Closed from 9/11/2001 to 9/16/2001 due to terrorist attacks in NYC.
     - Closed on 6/11/2004 due to Ronald Reagan's death.
     - Closed on 1/2/2007 due to Gerald Ford's death.
+    - Closed on 10/29/2012 and 10/30/2012 due to Hurricane Sandy.
     - Closed at 1:00 PM on Wednesday, July 3rd, 2013
     - Closed at 1:00 PM on Friday, December 31, 1999
     - Closed at 1:00 PM on Friday, December 26, 1997
@@ -133,6 +135,7 @@ class NYSEExchangeCalendar(MarketCalendar):
     def adhoc_holidays(self):
         return list(chain(
             September11Closings,
+            HurricaneGloriaClosings,
             HurricaneSandyClosings,
             USNationalDaysofMourning,
         ))

--- a/pandas_market_calendars/us_holidays.py
+++ b/pandas_market_calendars/us_holidays.py
@@ -142,6 +142,13 @@ BattleOfGettysburg = Holiday(
 # http://en.wikipedia.org/wiki/Aftermath_of_the_September_11_attacks
 September11Closings = date_range('2001-09-11', '2001-09-16', tz='UTC')
 
+# http://en.wikipedia.org/wiki/Hurricane_Gloria
+HurricaneGloriaClosings = date_range(
+    '1985-09-27',
+    '1985-09-27',
+    tz='UTC'
+)
+
 # http://en.wikipedia.org/wiki/Hurricane_sandy
 HurricaneSandyClosings = date_range(
     '2012-10-29',

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -53,11 +53,15 @@ def test_special_holidays():
     # 9/11
     # Sept 11, 12, 13, 14 2001
     nyse = NYSEExchangeCalendar()
-    good_dates = nyse.valid_days('2001-01-01', '2016-12-31')
+    good_dates = nyse.valid_days('1985-01-01', '2016-12-31')
     assert pd.Timestamp("9/11/2001") not in good_dates
     assert pd.Timestamp("9/12/2001") not in good_dates
     assert pd.Timestamp("9/13/2001") not in good_dates
     assert pd.Timestamp("9/14/2001") not in good_dates
+
+    # Hurricane Gloria
+    # Sept 27, 1985
+    assert pd.Timestamp("9/27/1985") not in good_dates
 
     # Hurricane Sandy
     # Oct 29, 30 2012


### PR DESCRIPTION
Add 1985-09-27 as a date the NYSE market was closed. http://s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf has other dates that may be of interest. I confirmed that Yahoo historical finance data does not contain an entry for 1985-09-27.