### PR TITLE
Automatic calendar registration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,12 @@ Quick Start
 .. code:: python
 
     import pandas_market_calendars as mcal
+    
+    # Create a calendar
     nyse = mcal.get_calendar('NYSE')
 
+    # Show available calendars
+    print(mcal.get_calendar_names())
 
 .. code:: python
 

--- a/docs/new_market.rst
+++ b/docs/new_market.rst
@@ -30,5 +30,3 @@ To create a new exchange (or OTC market):
 
       #. special_opens - returns a list of tuples. The tuple is (datetime.time of open, AbstractHolidayCalendar)
       #. special_opens_adhoc - returns a list of tuples. The tuple is (datetime.time of open, list of date strings)
-
-#. In the calendar_utils.py module add the new market to _calendars and any alias to _alias

--- a/docs/new_market.rst
+++ b/docs/new_market.rst
@@ -3,11 +3,12 @@ New Market or Exchange
 To create a new exchange (or OTC market):
 
 #. Create a new class that inherits from MarketCalendar
-#. In the new class create the following class attributes (variables) and set their values to datetime.time():
+#. In the new class create the following class attributes (variables):
 
-   #. open_time_default
-   #. close_time_default
-   #. regular_early_close
+   #. aliases = [...]
+   #. open_time_default = datetime.time(...)
+   #. close_time_default = datetime.time(...)
+   #. regular_early_close = datetime.time(...)
 
 #. Define the following property methods:
 

--- a/pandas_market_calendars/__init__.py
+++ b/pandas_market_calendars/__init__.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .market_calendar import MarketCalendar, get_calendar, get_calendar_names
+from .market_calendar import MarketCalendar
+from .calendar_registry import get_calendar, get_calendar_names
 from .calendar_utils import merge_schedules, date_range, convert_freq
 import pkg_resources
 

--- a/pandas_market_calendars/__init__.py
+++ b/pandas_market_calendars/__init__.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .market_calendar import MarketCalendar
-from .calendar_utils import get_calendar, merge_schedules, date_range, convert_freq
+from .market_calendar import MarketCalendar, get_calendar, get_calendar_names
+from .calendar_utils import merge_schedules, date_range, convert_freq
 import pkg_resources
 
 __version__ = pkg_resources.get_distribution('pandas_market_calendars').version

--- a/pandas_market_calendars/calendar_registry.py
+++ b/pandas_market_calendars/calendar_registry.py
@@ -1,0 +1,28 @@
+from .exchange_calendar_cfe import CFEExchangeCalendar
+from .exchange_calendar_ice import ICEExchangeCalendar
+from .exchange_calendar_nyse import NYSEExchangeCalendar
+from .exchange_calendar_cme import CMEExchangeCalendar
+from .exchange_calendar_bmf import BMFExchangeCalendar
+from .exchange_calendar_lse import LSEExchangeCalendar
+from .exchange_calendar_tsx import TSXExchangeCalendar
+from .exchange_calendar_eurex import EUREXExchangeCalendar
+from .exchange_calendar_six import SIXExchangeCalendar
+from .exchange_calendar_jpx import JPXExchangeCalendar
+from .market_calendar import MarketCalendar
+
+def get_calendar(name, open_time=None, close_time=None):
+    """
+    Retrieves an instance of an MarketCalendar whose name is given.
+
+    :param name: The name of the MarketCalendar to be retrieved.
+    :param open_time: Market open time override as datetime.time object. If None then default is used.
+    :param close_time: Market close time override as datetime.time object. If None then default is used.
+    :return: MarketCalendar of the desired calendar.
+    """
+    return MarketCalendar.factory(name, open_time=open_time, close_time=close_time)
+    
+def get_calendar_names():
+    """All Market Calendar names and aliases that can be used in "factory"
+    :return: list(str)
+    """
+    return MarketCalendar.calendar_names()

--- a/pandas_market_calendars/calendar_utils.py
+++ b/pandas_market_calendars/calendar_utils.py
@@ -1,55 +1,55 @@
 """
 Utilities to use with market_calendars
 """
-
 import pandas as pd
-from pandas_market_calendars.exchange_calendar_cfe import CFEExchangeCalendar
-from pandas_market_calendars.exchange_calendar_ice import ICEExchangeCalendar
-from pandas_market_calendars.exchange_calendar_nyse import NYSEExchangeCalendar
-from pandas_market_calendars.exchange_calendar_cme import CMEExchangeCalendar
-from pandas_market_calendars.exchange_calendar_bmf import BMFExchangeCalendar
-from pandas_market_calendars.exchange_calendar_lse import LSEExchangeCalendar
-from pandas_market_calendars.exchange_calendar_tsx import TSXExchangeCalendar
-from pandas_market_calendars.exchange_calendar_eurex import EUREXExchangeCalendar
-from pandas_market_calendars.exchange_calendar_six import SIXExchangeCalendar
-from pandas_market_calendars.exchange_calendar_jpx import JPXExchangeCalendar
 
-_calendars = {
-    'NYSE': NYSEExchangeCalendar,
-    'CME': CMEExchangeCalendar,
-    'ICE': ICEExchangeCalendar,
-    'CFE': CFEExchangeCalendar,
-    'BMF': BMFExchangeCalendar,
-    'LSE': LSEExchangeCalendar,
-    'TSX': TSXExchangeCalendar,
-    'EUREX': EUREXExchangeCalendar,
-    'SIX': SIXExchangeCalendar,
-    'JPX': JPXExchangeCalendar,
-}
+import warnings
+from collections import MutableMapping
+from . import market_calendar
 
-_aliases = {
-    'stock': 'NYSE',
-    'NASDAQ': 'NYSE',
-    'BATS': 'NYSE',
-    'CBOT': 'CME',
-    'COMEX': 'CME',
-    'NYMEX': 'CME',
-    'ICEUS': 'ICE',
-    'NYFE': 'ICE',
-}
+class DeprecatedDict(MutableMapping):
 
+    def __init__(self):
+        self._dict = market_calendar.MarketCalendar._regmeta_class_registry
 
-def get_calendar(name, open_time=None, close_time=None):
-    """
-    Retrieves an instance of an MarketCalendar whose name is given.
+    def _warn(self):
+        warnings.warn(
+            """
+            This dictionary will be removed from calendar_utils in future releases. 
+            Market Calendar's are registered automatically and there is no longer any 
+            need to access the registry directly."""
+        )
 
-    :param name: The name of the MarketCalendar to be retrieved.
-    :param open_time: Market open time override as datetime.time object. If None then default is used.
-    :param close_time: Market close time override as datetime.time object. If None then default is used.
-    :return: MarketCalendar of the desired calendar.
-    """
-    canonical_name = _aliases.get(name, name)
-    return _calendars[canonical_name](open_time, close_time)
+    def __getitem__(self, key):
+        self._warn()
+        return self._dict[key]
+
+    def __setitem__(self, key, value):
+        self._warn()
+        self._dict[key] = value
+
+    def __delitem__(self, key):
+        self._warn()
+        del self._dict[key]
+
+    def __iter__(self):
+        self._warn()
+        return iter(self._dict)
+
+    def __len__(self):
+        self._warn()
+        return len(self._dict)
+
+_calendars = _aliases = DeprecatedDict()
+
+def get_calendar(*args,**kwargs):
+    warnings.warn(
+            """
+            get_calendar has moved from calendar_utils to market_calendar. 
+            It will be removed from calendar_utils in future releases.""",
+            DeprecationWarning
+        )
+    market_calendar.get_calendar(*args,**kwargs)
 
 
 def merge_schedules(schedules, how='outer'):

--- a/pandas_market_calendars/calendar_utils.py
+++ b/pandas_market_calendars/calendar_utils.py
@@ -3,14 +3,15 @@ Utilities to use with market_calendars
 """
 import pandas as pd
 
+################## >>> Deprecated (remove in future releases)
 import warnings
 from collections import MutableMapping
-from . import market_calendar
+from . import calendar_registry
 
-class DeprecatedDict(MutableMapping):
+class DeprecatedRegistry(MutableMapping):
 
     def __init__(self):
-        self._dict = market_calendar.MarketCalendar._regmeta_class_registry
+        self._dict = calendar_registry.MarketCalendar._regmeta_class_registry
 
     def _warn(self):
         warnings.warn(
@@ -40,7 +41,7 @@ class DeprecatedDict(MutableMapping):
         self._warn()
         return len(self._dict)
 
-_calendars = _aliases = DeprecatedDict()
+_calendars = _aliases = DeprecatedRegistry()
 
 def get_calendar(*args,**kwargs):
     warnings.warn(
@@ -49,8 +50,9 @@ def get_calendar(*args,**kwargs):
             It will be removed from calendar_utils in future releases.""",
             DeprecationWarning
         )
-    market_calendar.get_calendar(*args,**kwargs)
+    calendar_registry.get_calendar(*args,**kwargs)
 
+################## <<< Deprecated (remove in future releases)
 
 def merge_schedules(schedules, how='outer'):
     """

--- a/pandas_market_calendars/class_registry.py
+++ b/pandas_market_calendars/class_registry.py
@@ -25,10 +25,14 @@ def _regmeta_register_class(cls, regcls, name):
     :param regcls(class): class to be registered
     :param name(str): name of the class to be registered
     """
-    cls._regmeta_class_registry[name] = regcls
     if hasattr(regcls, 'aliases'):
-        for alias in regcls.aliases:
-            cls._regmeta_class_registry[alias] = regcls
+        if regcls.aliases:
+            for alias in regcls.aliases:
+                cls._regmeta_class_registry[alias] = regcls
+        else:
+            cls._regmeta_class_registry[name] = regcls
+    else:
+        cls._regmeta_class_registry[name] = regcls
 
 def _regmeta_classes(cls):
     return list(cls._regmeta_class_registry.keys())

--- a/pandas_market_calendars/class_registry.py
+++ b/pandas_market_calendars/class_registry.py
@@ -1,0 +1,58 @@
+def _regmeta_class_factory(cls, name):
+    """
+    :param cls(RegisteryMeta): registration meta class
+    :param name(str): name of class
+    :return: class
+    """
+    if name in cls._regmeta_class_registry:
+        return cls._regmeta_class_registry[name]
+    else:
+        raise RuntimeError('Class {} is not one of the registered classes: {}'.format(name,cls._regmeta_class_registry.keys()))
+        
+def _regmeta_instance_factory(cls, name, *args,**kwargs):
+    """
+    :param cls(RegisteryMeta): registration meta class
+    :param name(str): name of class that needs to be instantiated
+    :param args(Optional(tuple)): instance positional arguments
+    :param kwargs(Optional(dict)): instance named arguments
+    :return: class instance
+    """
+    return cls._regmeta_class_factory(name)(*args,**kwargs)
+
+def _regmeta_register_class(cls, regcls, name):
+    """
+    :param cls(RegisteryMeta): registration base class
+    :param regcls(class): class to be registered
+    :param name(str): name of the class to be registered
+    """
+    cls._regmeta_class_registry[name] = regcls
+    if hasattr(regcls, 'aliases'):
+        for alias in regcls.aliases:
+            cls._regmeta_class_registry[alias] = regcls
+
+def _regmeta_classes(cls):
+    return list(cls._regmeta_class_registry.keys())
+
+class RegisteryMeta(type):
+    """
+    Metaclass used to register all classes inheriting from RegisteryMeta 
+    """
+    
+    def __new__(self, name, bases, attr):
+        cls = super(RegisteryMeta, self).__new__(self, name, bases, attr)
+        
+        if not hasattr(cls,'_regmeta_class_registry'):
+            cls._regmeta_class_registry = {}
+            cls._regmeta_class_factory = classmethod(_regmeta_class_factory)
+            cls._regmeta_instance_factory = classmethod(_regmeta_instance_factory)
+            cls._regmeta_register_class = classmethod(_regmeta_register_class)
+            cls._regmeta_classes = classmethod(_regmeta_classes)
+
+        return cls
+        
+    def __init__(cls, name, bases, attr):
+        cls._regmeta_register_class(cls,name)
+        for b in bases:
+            if hasattr(b,'_regmeta_register_class'):
+                b._regmeta_register_class(cls,name)
+        super(RegisteryMeta, cls).__init__(name, bases, attr)

--- a/pandas_market_calendars/exchange_calendar_bmf.py
+++ b/pandas_market_calendars/exchange_calendar_bmf.py
@@ -173,6 +173,7 @@ class BMFExchangeCalendar(MarketCalendar):
     - Day before New Year's Eve (December 30 if NYE falls on a Saturday)
     - New Year's Eve (December 31)
     """
+    aliases = ['BMF']
 
     @property
     def name(self):

--- a/pandas_market_calendars/exchange_calendar_cfe.py
+++ b/pandas_market_calendars/exchange_calendar_cfe.py
@@ -31,6 +31,8 @@ class CFEExchangeCalendar(MarketCalendar):
 
     (We are ignoring extended trading hours for now)
     """
+    aliases = ['CFE']
+
     @property
     def name(self):
         return "CFE"

--- a/pandas_market_calendars/exchange_calendar_cme.py
+++ b/pandas_market_calendars/exchange_calendar_cme.py
@@ -52,6 +52,8 @@ class CMEExchangeCalendar(MarketCalendar):
     - Good Friday
     - Christmas
     """
+    aliases = ['CME','CBOT','COMEX','NYMEX']
+
     @property
     def name(self):
         return "CME"

--- a/pandas_market_calendars/exchange_calendar_eurex.py
+++ b/pandas_market_calendars/exchange_calendar_eurex.py
@@ -80,6 +80,7 @@ class EUREXExchangeCalendar(MarketCalendar):
     Exchange calendar for EUREX
 
     """
+    aliases = ['EUREX']
 
     @property
     def name(self):

--- a/pandas_market_calendars/exchange_calendar_ice.py
+++ b/pandas_market_calendars/exchange_calendar_ice.py
@@ -30,6 +30,8 @@ class ICEExchangeCalendar(MarketCalendar):
 
     https://www.theice.com/publicdocs/futures_us/ICE_Futures_US_Regular_Trading_Hours.pdf # noqa
     """
+    aliases = ['ICE','ICEUS','NYFE']
+
     @property
     def name(self):
         return "ICE"

--- a/pandas_market_calendars/exchange_calendar_jpx.py
+++ b/pandas_market_calendars/exchange_calendar_jpx.py
@@ -20,6 +20,7 @@ class JPXExchangeCalendar(MarketCalendar):
     LUNCH BREAK :facepalm: : 11:30 AM - 12:30 PM Asia/Tokyo
     Close Time: 4:00 PM, Asia/Tokyo
     """
+    aliases = ['JPX']
 
     regular_early_close = time(13)
     lunch_start = time(11, 30)

--- a/pandas_market_calendars/exchange_calendar_lse.py
+++ b/pandas_market_calendars/exchange_calendar_lse.py
@@ -120,6 +120,7 @@ class LSEExchangeCalendar(MarketCalendar):
     - Boxing Day
     - Dec. 28th (if Boxing Day is on a weekend)
     """
+    aliases = ['LSE']
 
     @property
     def name(self):

--- a/pandas_market_calendars/exchange_calendar_nyse.py
+++ b/pandas_market_calendars/exchange_calendar_nyse.py
@@ -160,7 +160,8 @@ class NYSEExchangeCalendar(MarketCalendar):
     will be in 2025.  If someone is still maintaining this code in 2025, then
     we've done alright...and we should check if it's a half day.
     """
-
+    aliases = ['NYSE','stock','NASDAQ','BATS']
+    
     regular_early_close = time(13)
 
     @property

--- a/pandas_market_calendars/exchange_calendar_six.py
+++ b/pandas_market_calendars/exchange_calendar_six.py
@@ -108,6 +108,7 @@ class SIXExchangeCalendar(MarketCalendar):
     Exchange calendar for SIX
 
     """
+    aliases = ['SIX']
 
     @property
     def name(self):

--- a/pandas_market_calendars/exchange_calendar_tsx.py
+++ b/pandas_market_calendars/exchange_calendar_tsx.py
@@ -92,6 +92,7 @@ class TSXExchangeCalendar(MarketCalendar):
     - Boxing Day
     - Dec. 28th (if Boxing Day is on a weekend)
     """
+    aliases = ['TSX','TSXV']
 
     @property
     def name(self):

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -16,15 +16,16 @@
 
 import six
 from itertools import compress
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex
 from pandas.tseries.offsets import CustomBusinessDay
+from .class_registry import RegisteryMeta
 
 MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY = range(7)
 
 
-class MarketCalendar(six.with_metaclass(ABCMeta)):
+class MarketCalendar(six.with_metaclass(RegisteryMeta)):
     """
     An MarketCalendar represents the timing information of a single market or exchange.
     Unless otherwise noted all times are in UTC and use Pandas data structures.
@@ -37,6 +38,23 @@ class MarketCalendar(six.with_metaclass(ABCMeta)):
         """
         self._open_time = self.open_time_default if open_time is None else open_time
         self._close_time = self.close_time_default if close_time is None else close_time
+
+    @classmethod
+    def factory(self, name, open_time=None, close_time=None):
+        """
+        :param name: The name of the MarketCalendar to be retrieved.
+        :param open_time: Market open time override as datetime.time object. If None then default is used.
+        :param close_time: Market close time override as datetime.time object. If None then default is used.
+        :return: MarketCalendar of the desired calendar.
+        """
+        return self._regmeta_instance_factory(name, open_time=open_time, close_time=close_time)
+
+    @classmethod
+    def calendar_names(cls):
+        """All Market Calendar names and aliases that can be used in "factory"
+        :return: list(str)
+        """
+        return [cal for cal in cls._regmeta_classes() if cal!='MarketCalendar']
 
     @property
     @abstractmethod
@@ -289,6 +307,22 @@ class MarketCalendar(six.with_metaclass(ABCMeta)):
             end,
         )
 
+def get_calendar(name, open_time=None, close_time=None):
+    """
+    Retrieves an instance of an MarketCalendar whose name is given.
+
+    :param name: The name of the MarketCalendar to be retrieved.
+    :param open_time: Market open time override as datetime.time object. If None then default is used.
+    :param close_time: Market close time override as datetime.time object. If None then default is used.
+    :return: MarketCalendar of the desired calendar.
+    """
+    return MarketCalendar.factory(name, open_time=open_time, close_time=close_time)
+
+def get_calendar_names():
+    """All Market Calendar names and aliases that can be used in "factory"
+    :return: list(str)
+    """
+    return MarketCalendar.calendar_names()
 
 def days_at_time(days, t, tz, day_offset=0):
     """

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -16,7 +16,7 @@
 
 import six
 from itertools import compress
-from abc import abstractmethod
+from abc import ABCMeta,abstractmethod
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex
 from pandas.tseries.offsets import CustomBusinessDay
@@ -24,8 +24,9 @@ from .class_registry import RegisteryMeta
 
 MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY = range(7)
 
+MarketCalendarMeta = type('MarketCalendarMeta', (ABCMeta, RegisteryMeta), {})
 
-class MarketCalendar(six.with_metaclass(RegisteryMeta)):
+class MarketCalendar(six.with_metaclass(MarketCalendarMeta)):
     """
     An MarketCalendar represents the timing information of a single market or exchange.
     Unless otherwise noted all times are in UTC and use Pandas data structures.

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -307,23 +307,6 @@ class MarketCalendar(six.with_metaclass(RegisteryMeta)):
             end,
         )
 
-def get_calendar(name, open_time=None, close_time=None):
-    """
-    Retrieves an instance of an MarketCalendar whose name is given.
-
-    :param name: The name of the MarketCalendar to be retrieved.
-    :param open_time: Market open time override as datetime.time object. If None then default is used.
-    :param close_time: Market close time override as datetime.time object. If None then default is used.
-    :return: MarketCalendar of the desired calendar.
-    """
-    return MarketCalendar.factory(name, open_time=open_time, close_time=close_time)
-
-def get_calendar_names():
-    """All Market Calendar names and aliases that can be used in "factory"
-    :return: list(str)
-    """
-    return MarketCalendar.calendar_names()
-
 def days_at_time(days, t, tz, day_offset=0):
     """
     Create an index of days at time ``t``, interpreted in timezone ``tz``. The returned index is localized to UTC.

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -32,7 +32,6 @@ def test_inheritance():
             super(Class1a, self).__init__(arg0,arg1,**kwargs)
             
     class Class1b(Class1):
-        aliases = ["class 1b"]
         def __init__(self,arg0,arg1,arg1b,kw1b=None,**kwargs):
             self.arg1b = arg1b
             self.kw1b = kw1b
@@ -48,7 +47,7 @@ def test_inheritance():
     assert set(Class1._regmeta_classes()) == set(['Class1', 'class 1a', 'Class1b', 'class 12a'])
     assert set(Class2._regmeta_classes()) == set(['class 2', 'class 12a'])
     
-    o = factory1("class 1","0","1",kw0="k0",kw1="k1")
+    o = factory1("Class1","0","1",kw0="k0",kw1="k1")
     assert (o.arg0,o.arg1,o.kw0,o.kw1) == ("0","1","k0","k1")
     assert Class1 == o.__class__
     
@@ -56,7 +55,7 @@ def test_inheritance():
     assert (o.arg0,o.arg1,o.arg1a,o.kw0,o.kw1,o.kw1a) == ("0","1","a","k0","k1","k1a")
     assert Class1a == o.__class__
     
-    o = factory1("class 1b","0","1","b",kw0="k0",kw1="k1",kw1b="k1b")
+    o = factory1("Class1b","0","1","b",kw0="k0",kw1="k1",kw1b="k1b")
     assert (o.arg0,o.arg1,o.arg1b,o.kw0,o.kw1,o.kw1b) == ("0","1","b","k0","k1","k1b")
     assert Class1b == o.__class__
     

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -17,6 +17,7 @@ def test_inheritance():
     factory1 = Class1._regmeta_instance_factory
     
     class Class2(six.with_metaclass(RegisteryMeta,Base)):
+        aliases = ["class 2"]
         def __init__(self,arg0,arg2,kw2=None,**kwargs):
             self.arg2 = arg2
             self.kw2 = kw2
@@ -44,48 +45,28 @@ def test_inheritance():
             self.kw12a = kw12a
             super(Class12a, self).__init__(arg0=arg0,arg1=arg1,arg2=arg2,**kwargs)
     
-    assert set(Class1._regmeta_classes()) == set(['Class1', 'Class1a', 'Class1b', 'Class12a', 'class 1a', 'class 1b', 'class 12a'])
-    assert set(Class2._regmeta_classes()) == set(['Class2', 'Class12a', 'class 12a'])
+    assert set(Class1._regmeta_classes()) == set(['Class1', 'class 1a', 'Class1b', 'class 12a'])
+    assert set(Class2._regmeta_classes()) == set(['class 2', 'class 12a'])
     
-    o = factory1("Class1","0","1",kw0="k0",kw1="k1")
+    o = factory1("class 1","0","1",kw0="k0",kw1="k1")
     assert (o.arg0,o.arg1,o.kw0,o.kw1) == ("0","1","k0","k1")
     assert Class1 == o.__class__
-    
-    o = factory1("Class1a","0","1","a",kw0="k0",kw1="k1",kw1a="k1a")
-    assert (o.arg0,o.arg1,o.arg1a,o.kw0,o.kw1,o.kw1a) == ("0","1","a","k0","k1","k1a")
-    assert Class1a == o.__class__
     
     o = factory1("class 1a","0","1","a",kw0="k0",kw1="k1",kw1a="k1a")
     assert (o.arg0,o.arg1,o.arg1a,o.kw0,o.kw1,o.kw1a) == ("0","1","a","k0","k1","k1a")
     assert Class1a == o.__class__
     
-    o = factory1("Class1b","0","1","b",kw0="k0",kw1="k1",kw1b="k1b")
-    assert (o.arg0,o.arg1,o.arg1b,o.kw0,o.kw1,o.kw1b) == ("0","1","b","k0","k1","k1b")
-    assert Class1b == o.__class__
-    
     o = factory1("class 1b","0","1","b",kw0="k0",kw1="k1",kw1b="k1b")
     assert (o.arg0,o.arg1,o.arg1b,o.kw0,o.kw1,o.kw1b) == ("0","1","b","k0","k1","k1b")
     assert Class1b == o.__class__
-    
-    o = factory1("Class12a","0","1","2","a",kw0="k0",kw1="k1",kw2="k2",kw12a="k12a")
-    assert (o.arg0,o.arg1,o.arg2,o.arg12a,o.kw0,o.kw1,o.kw2,o.kw12a) == ("0","1","2","a","k0","k1","k2","k12a")
-    assert Class12a == o.__class__
     
     o = factory1("class 12a","0","1","2","a",kw0="k0",kw1="k1",kw2="k2",kw12a="k12a")
     assert (o.arg0,o.arg1,o.arg2,o.arg12a,o.kw0,o.kw1,o.kw2,o.kw12a) == ("0","1","2","a","k0","k1","k2","k12a")
     assert Class12a == o.__class__
     
-    o = factory2("Class2","0","2",kw0="k0",kw2="k2")
+    o = factory2("class 2","0","2",kw0="k0",kw2="k2")
     assert (o.arg0,o.arg2,o.kw0,o.kw2) == ("0","2","k0","k2")
     assert Class2 == o.__class__
-    
-    o = factory2("Class12a","0","1","2","a",kw0="k0",kw1="k1",kw2="k2",kw12a="k12a")
-    assert (o.arg0,o.arg1,o.arg2,o.arg12a,o.kw0,o.kw1,o.kw2,o.kw12a) == ("0","1","2","a","k0","k1","k2","k12a")
-    assert Class12a == o.__class__
-    
-    o = factory2("class 12a","0","1","2","a",kw0="k0",kw1="k1",kw2="k2",kw12a="k12a")
-    assert (o.arg0,o.arg1,o.arg2,o.arg12a,o.kw0,o.kw1,o.kw2,o.kw12a) == ("0","1","2","a","k0","k1","k2","k12a")
-    assert Class12a == o.__class__
 
 def test_metamixing():
     BaseMeta = type('BaseMeta', (ABCMeta, RegisteryMeta), {})
@@ -96,7 +77,7 @@ def test_metamixing():
             pass
 
     class Class1(Base):
-        aliases = ['c1']
+        aliases = ['c1','c 1']
         def test(self):
             return 123
 
@@ -107,6 +88,6 @@ def test_metamixing():
     else:
         raise RuntimeError('Abstract class is instantiated')
 
-    o1 = Base._regmeta_instance_factory('Class1')
-    o2 = Base._regmeta_instance_factory('c1')
-    assert o1.test(),o2.test()
+    o1 = Base._regmeta_instance_factory('c1')
+    o2 = Base._regmeta_instance_factory('c 1')
+    assert o1.test() == o2.test()

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -1,0 +1,111 @@
+from abc import ABCMeta, abstractmethod
+from pandas_market_calendars.class_registry import RegisteryMeta
+
+def test_inheritance():
+    class Base(object):
+        def __init__(self,arg0,kw0=None):
+            self.arg0 = arg0
+            self.kw0 = kw0
+            super(Base,self).__init__()
+
+    class Class1(Base,metaclass=RegisteryMeta):
+        def __init__(self,arg0,arg1,kw1=None,**kwargs):
+            self.arg1 = arg1
+            self.kw1 = kw1
+            super(Class1, self).__init__(arg0,**kwargs)
+    factory1 = Class1._regmeta_instance_factory
+    
+    class Class2(Base,metaclass=RegisteryMeta):
+        def __init__(self,arg0,arg2,kw2=None,**kwargs):
+            self.arg2 = arg2
+            self.kw2 = kw2
+            super(Class2, self).__init__(arg0,**kwargs)
+    factory2 = Class2._regmeta_instance_factory
+    
+    class Class1a(Class1):
+        aliases = ["class 1a"]
+        def __init__(self,arg0,arg1,arg1a,kw1a=None,**kwargs):
+            self.arg1a = arg1a
+            self.kw1a = kw1a
+            super(Class1a, self).__init__(arg0,arg1,**kwargs)
+            
+    class Class1b(Class1):
+        aliases = ["class 1b"]
+        def __init__(self,arg0,arg1,arg1b,kw1b=None,**kwargs):
+            self.arg1b = arg1b
+            self.kw1b = kw1b
+            super(Class1b, self).__init__(arg0,arg1,**kwargs)
+
+    class Class12a(Class1,Class2):
+        aliases = ["class 12a"]
+        def __init__(self,arg0,arg1,arg2,arg12a,kw12a=None,**kwargs):
+            self.arg12a = arg12a
+            self.kw12a = kw12a
+            super(Class12a, self).__init__(arg0=arg0,arg1=arg1,arg2=arg2,**kwargs)
+    
+    assert set(Class1._regmeta_class_registry.keys()) == set(['Class1', 'Class1a', 'Class1b', 'Class12a', 'class 1a', 'class 1b', 'class 12a'])
+    assert set(Class2._regmeta_class_registry.keys()) == set(['Class2', 'Class12a', 'class 12a'])
+    
+    o = factory1("Class1","0","1",kw0="k0",kw1="k1")
+    assert (o.arg0,o.arg1,o.kw0,o.kw1) == ("0","1","k0","k1")
+    assert Class1 == o.__class__
+    
+    o = factory1("Class1a","0","1","a",kw0="k0",kw1="k1",kw1a="k1a")
+    assert (o.arg0,o.arg1,o.arg1a,o.kw0,o.kw1,o.kw1a) == ("0","1","a","k0","k1","k1a")
+    assert Class1a == o.__class__
+    
+    o = factory1("class 1a","0","1","a",kw0="k0",kw1="k1",kw1a="k1a")
+    assert (o.arg0,o.arg1,o.arg1a,o.kw0,o.kw1,o.kw1a) == ("0","1","a","k0","k1","k1a")
+    assert Class1a == o.__class__
+    
+    o = factory1("Class1b","0","1","b",kw0="k0",kw1="k1",kw1b="k1b")
+    assert (o.arg0,o.arg1,o.arg1b,o.kw0,o.kw1,o.kw1b) == ("0","1","b","k0","k1","k1b")
+    assert Class1b == o.__class__
+    
+    o = factory1("class 1b","0","1","b",kw0="k0",kw1="k1",kw1b="k1b")
+    assert (o.arg0,o.arg1,o.arg1b,o.kw0,o.kw1,o.kw1b) == ("0","1","b","k0","k1","k1b")
+    assert Class1b == o.__class__
+    
+    o = factory1("Class12a","0","1","2","a",kw0="k0",kw1="k1",kw2="k2",kw12a="k12a")
+    assert (o.arg0,o.arg1,o.arg2,o.arg12a,o.kw0,o.kw1,o.kw2,o.kw12a) == ("0","1","2","a","k0","k1","k2","k12a")
+    assert Class12a == o.__class__
+    
+    o = factory1("class 12a","0","1","2","a",kw0="k0",kw1="k1",kw2="k2",kw12a="k12a")
+    assert (o.arg0,o.arg1,o.arg2,o.arg12a,o.kw0,o.kw1,o.kw2,o.kw12a) == ("0","1","2","a","k0","k1","k2","k12a")
+    assert Class12a == o.__class__
+    
+    o = factory2("Class2","0","2",kw0="k0",kw2="k2")
+    assert (o.arg0,o.arg2,o.kw0,o.kw2) == ("0","2","k0","k2")
+    assert Class2 == o.__class__
+    
+    o = factory2("Class12a","0","1","2","a",kw0="k0",kw1="k1",kw2="k2",kw12a="k12a")
+    assert (o.arg0,o.arg1,o.arg2,o.arg12a,o.kw0,o.kw1,o.kw2,o.kw12a) == ("0","1","2","a","k0","k1","k2","k12a")
+    assert Class12a == o.__class__
+    
+    o = factory2("class 12a","0","1","2","a",kw0="k0",kw1="k1",kw2="k2",kw12a="k12a")
+    assert (o.arg0,o.arg1,o.arg2,o.arg12a,o.kw0,o.kw1,o.kw2,o.kw12a) == ("0","1","2","a","k0","k1","k2","k12a")
+    assert Class12a == o.__class__
+
+def test_metamixing():
+    BaseMeta = type('BaseMeta', (ABCMeta, RegisteryMeta), {})
+
+    class Base(metaclass=BaseMeta):
+        @abstractmethod
+        def test(self):
+            pass
+
+    class Class1(Base):
+        aliases = ['c1']
+        def test(self):
+            return 123
+
+    try:
+        Base()
+    except TypeError:
+        pass
+    else:
+        raise RuntimeError('Abstract class is instantiated')
+
+    o1 = Base._regmeta_instance_factory('Class1')
+    o2 = Base._regmeta_instance_factory('c1')
+    assert o1.test(),o2.test()

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -1,3 +1,4 @@
+import six
 from abc import ABCMeta, abstractmethod
 from pandas_market_calendars.class_registry import RegisteryMeta
 
@@ -8,14 +9,14 @@ def test_inheritance():
             self.kw0 = kw0
             super(Base,self).__init__()
 
-    class Class1(Base,metaclass=RegisteryMeta):
+    class Class1(six.with_metaclass(RegisteryMeta,Base)):
         def __init__(self,arg0,arg1,kw1=None,**kwargs):
             self.arg1 = arg1
             self.kw1 = kw1
             super(Class1, self).__init__(arg0,**kwargs)
     factory1 = Class1._regmeta_instance_factory
     
-    class Class2(Base,metaclass=RegisteryMeta):
+    class Class2(six.with_metaclass(RegisteryMeta,Base)):
         def __init__(self,arg0,arg2,kw2=None,**kwargs):
             self.arg2 = arg2
             self.kw2 = kw2
@@ -43,8 +44,8 @@ def test_inheritance():
             self.kw12a = kw12a
             super(Class12a, self).__init__(arg0=arg0,arg1=arg1,arg2=arg2,**kwargs)
     
-    assert set(Class1._regmeta_class_registry.keys()) == set(['Class1', 'Class1a', 'Class1b', 'Class12a', 'class 1a', 'class 1b', 'class 12a'])
-    assert set(Class2._regmeta_class_registry.keys()) == set(['Class2', 'Class12a', 'class 12a'])
+    assert set(Class1._regmeta_classes()) == set(['Class1', 'Class1a', 'Class1b', 'Class12a', 'class 1a', 'class 1b', 'class 12a'])
+    assert set(Class2._regmeta_classes()) == set(['Class2', 'Class12a', 'class 12a'])
     
     o = factory1("Class1","0","1",kw0="k0",kw1="k1")
     assert (o.arg0,o.arg1,o.kw0,o.kw1) == ("0","1","k0","k1")
@@ -89,7 +90,7 @@ def test_inheritance():
 def test_metamixing():
     BaseMeta = type('BaseMeta', (ABCMeta, RegisteryMeta), {})
 
-    class Base(metaclass=BaseMeta):
+    class Base(six.with_metaclass(BaseMeta)):
         @abstractmethod
         def test(self):
             pass

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -20,8 +20,7 @@ from pandas.util.testing import assert_series_equal, assert_frame_equal, assert_
 from itertools import chain
 import pytest
 
-from pandas_market_calendars import get_calendar
-from pandas_market_calendars.calendar_utils import _calendars, _aliases
+from pandas_market_calendars import get_calendar, get_calendar_names
 from pandas_market_calendars.market_calendar import days_at_time, MarketCalendar, clean_dates
 
 from pandas.tseries.holiday import AbstractHolidayCalendar
@@ -77,9 +76,7 @@ class FakeCalendar(MarketCalendar):
 
 
 def test_default_calendars():
-    names = [x for x in _calendars]
-    names.extend([x for x in _aliases])
-    for name in names:
+    for name in get_calendar_names():
         assert get_calendar(name) is not None
 
 


### PR DESCRIPTION
Implementation of feature request #43:
-  Calendar registration happens automatically by deriving from MarketCalendar.
-  Calendars are registered under their aliases (provided as a class attribute "aliases").
-  If a Calendar class does not have an "aliases" attribute, the class name is used instead.
-  A list of registered calendars can be retrieved with "get_calendar_names".
-  Registered calendars can be instantiated as before, e.g. get_calendar('NYSE').
-  Some attributes of calendar_utils are marked as deprecated (get_calendar, _calendars, _aliases). They can be removed in the future.

Currently get_calendar_names returns:
['CFE', 'ICE', 'ICEUS', 'NYFE', 'NYSE', 'stock', 'NASDAQ', 'BATS', 'CME', 'CBOT', 'COMEX', 'NYMEX', 'BMF', 'LSE', 'TSX', 'TSXV', 'EUREX', 'SIX', 'JPX']