### PR TITLE
Implemented OSE (Oslo Stock Exchange)

### DIFF
--- a/docs/calendars.rst
+++ b/docs/calendars.rst
@@ -14,4 +14,5 @@ Exchange  TSX    TSXExchangeCalendar     Yes        Quantopian innominate227
 Exchange  EUREX  EUREXExchangeCalendar   Yes        kewlfft    kewlfft
 Exchange  JPX    JPXExchangeCalendar     Yes        gabalese   mgellman-radix
 Exchange  SIX    SIXExchangeCalendar     Yes        oliverfu89
+Exchange  OSE    OSEExchangeCalendar     Yes        busteren
 ========= ====== ===================== ============ ========== ==============

--- a/docs/pandas_market_calendars.rst
+++ b/docs/pandas_market_calendars.rst
@@ -76,18 +76,18 @@ pandas\_market\_calendars\.exchange\_calendar\_nyse module
     :undoc-members:
     :show-inheritance:
 
-pandas\_market\_calendars\.exchange\_calendar\_tsx module
----------------------------------------------------------
+pandas\_market\_calendars\.exchange\_calendar\_ose module
+----------------------------------------------------------
 
-.. automodule:: pandas_market_calendars.exchange_calendar_tsx
+.. automodule:: pandas_market_calendars.exchange_calendar_ose
     :members:
     :undoc-members:
     :show-inheritance:
 
-pandas\_market\_calendars\.jpx\_autumnal\_equinox module
---------------------------------------------------------
+pandas\_market\_calendars\.exchange\_calendar\_tsx module
+---------------------------------------------------------
 
-.. automodule:: pandas_market_calendars.jpx_autumnal_equinox
+.. automodule:: pandas_market_calendars.exchange_calendar_tsx
     :members:
     :undoc-members:
     :show-inheritance:

--- a/pandas_market_calendars/calendar_registry.py
+++ b/pandas_market_calendars/calendar_registry.py
@@ -1,14 +1,6 @@
-from .exchange_calendar_cfe import CFEExchangeCalendar
-from .exchange_calendar_ice import ICEExchangeCalendar
-from .exchange_calendar_nyse import NYSEExchangeCalendar
-from .exchange_calendar_cme import CMEExchangeCalendar
-from .exchange_calendar_bmf import BMFExchangeCalendar
-from .exchange_calendar_lse import LSEExchangeCalendar
-from .exchange_calendar_tsx import TSXExchangeCalendar
-from .exchange_calendar_eurex import EUREXExchangeCalendar
-from .exchange_calendar_six import SIXExchangeCalendar
-from .exchange_calendar_jpx import JPXExchangeCalendar
+
 from .market_calendar import MarketCalendar
+
 
 def get_calendar(name, open_time=None, close_time=None):
     """
@@ -20,7 +12,8 @@ def get_calendar(name, open_time=None, close_time=None):
     :return: MarketCalendar of the desired calendar.
     """
     return MarketCalendar.factory(name, open_time=open_time, close_time=close_time)
-    
+
+
 def get_calendar_names():
     """All Market Calendar names and aliases that can be used in "factory"
     :return: list(str)

--- a/pandas_market_calendars/exchange_calendar_ose.py
+++ b/pandas_market_calendars/exchange_calendar_ose.py
@@ -1,0 +1,159 @@
+from datetime import time
+
+from pandas.tseries.holiday import AbstractHolidayCalendar
+from pandas.tseries.holiday import (
+    Holiday,
+    GoodFriday,
+    EasterMonday
+)
+from pandas.tseries.offsets import Easter, Day
+from pytz import timezone
+
+from .market_calendar import MarketCalendar
+
+OSENewYearsDay = Holiday(
+    "New Year's Day",
+    month=1,
+    day=1
+)
+
+OSEWednesdayBeforeEaster = Holiday(
+    "Wednesday before Easter",
+    month=1,
+    day=1,
+    offset=[Easter(), Day(-4)]
+
+)
+
+OSEMaundyThursday = Holiday(
+    "Maundy Thursday",
+    month=1,
+    day=1,
+    offset=[Easter(), Day(-3)]
+)
+
+OSEGoodFriday = GoodFriday
+
+OSEEasterMonday = EasterMonday
+
+OSELabourDay = Holiday(
+    "Labour Day",
+    month=5,
+    day=1
+)
+
+OSEConstitutionDay = Holiday(
+    "Constitution Day",
+    month=5,
+    day=17
+)
+
+OSEWhitMonday = Holiday(
+    "Whit Monday",
+    month=1,
+    day=1,
+    offset=[Easter(), Day(50)]
+)
+
+OSEAscensionDay = Holiday(
+    "Ascension Day",
+    month=1,
+    day=1,
+    offset=[Easter(), Day(39)]
+)
+
+OSEChristmasEve = Holiday(
+    "Christmas Eve",
+    month=12,
+    day=24,
+)
+
+OSEChristmasDay = Holiday(
+    "Christmas Day",
+    month=12,
+    day=25
+)
+
+OSEBoxingDay = Holiday(
+    "Boxing Day",
+    month=12,
+    day=26
+)
+
+OSENewYearsEve = Holiday(
+    "New Year's Eve",
+    month=12,
+    day=31
+)
+
+
+class OSEExchangeCalendar(MarketCalendar):
+    """
+    Exchange calendar for Oslo Stock Exchange
+
+    Note these dates are only checked against 2017, 2018 and 2019
+    https://www.oslobors.no/ob_eng/Oslo-Boers/About-Oslo-Boers/Opening-hours
+
+    Opening times for the regular trading of equities (not including closing auction call)
+    Open Time: 9:00 AM, CEST/EST
+    Close Time: 4:20 PM, CEST/EST
+
+    Regularly-Observed Holidays (not necessarily in order):
+    - New Years Day
+    - Wednesday before Easter (Half trading day)
+    - Maundy Thursday
+    - Good Friday
+    - Easter Monday
+    - Labour Day
+    - Ascension Day
+    - Constitution Day
+    - Whit Monday
+    - Christmas Eve
+    - Christmas Day
+    - Boxing Day
+    - New Year's Eve
+    """
+
+    aliases = ['OSE']
+
+    @property
+    def name(self):
+        return "OSE"
+
+    @property
+    def tz(self):
+        return timezone("Europe/Oslo")
+
+    @property
+    def open_time_default(self):
+        return time(9, 0, tzinfo=self.tz)
+
+    @property
+    def close_time_default(self):
+        return time(16, 20, tzinfo=self.tz)
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            OSENewYearsDay,
+            OSEMaundyThursday,
+            OSEGoodFriday,
+            OSEEasterMonday,
+            OSELabourDay,
+            OSEConstitutionDay,
+            OSEWhitMonday,
+            OSEAscensionDay,
+            OSEChristmasEve,
+            OSEChristmasDay,
+            OSEBoxingDay,
+            OSENewYearsEve
+        ])
+
+    @property
+    def special_closes(self):
+        return [(
+            time(13, 0, tzinfo=self.tz),
+            AbstractHolidayCalendar(rules=[
+                OSEWednesdayBeforeEaster
+            ])
+        )]

--- a/tests/test_ose_calendar.py
+++ b/tests/test_ose_calendar.py
@@ -1,0 +1,164 @@
+"""
+    Currently only 2017, 2018 and 2019 dates are confirmed.
+
+    Dates based on:
+    - (not this is for OBX and Equity Derivatives)
+    https://www.oslobors.no/obnewsletter/download/1e05ee05a9c1a472da4c715435ff1314/file/file/Bortfallskalender%202017-2019.pdf
+    - https://www.oslobors.no/ob_eng/Oslo-Boers/About-Oslo-Boers/Opening-hours
+"""
+
+import pandas as pd
+import pytz
+
+from pandas_market_calendars.exchange_calendar_ose import OSEExchangeCalendar
+
+TIMEZONE = pytz.timezone("Europe/Oslo")
+
+
+def test_time_zone():
+    assert OSEExchangeCalendar().tz == pytz.timezone("Europe/Oslo")
+
+
+def test_name():
+    assert OSEExchangeCalendar().name == "OSE"
+
+
+def test_open_time_tz():
+    ose = OSEExchangeCalendar()
+    assert ose.open_time.tzinfo == ose.tz
+
+
+def test_close_time_tz():
+    ose = OSEExchangeCalendar()
+    assert ose.close_time.tzinfo == ose.tz
+
+
+def test_2017_calendar():
+    ose = OSEExchangeCalendar()
+    ose_schedule = ose.schedule(
+        start_date=pd.Timestamp("2017-04-11", tz=TIMEZONE),
+        end_date=pd.Timestamp("2017-04-13", tz=TIMEZONE)
+    )
+
+    regular_holidays_2017 = [
+        pd.Timestamp("2017-04-13", tz=TIMEZONE),
+        pd.Timestamp("2017-04-14", tz=TIMEZONE),
+        pd.Timestamp("2017-04-17", tz=TIMEZONE),
+        pd.Timestamp("2017-05-01", tz=TIMEZONE),
+        pd.Timestamp("2017-05-17", tz=TIMEZONE),
+        pd.Timestamp("2017-05-25", tz=TIMEZONE),
+        pd.Timestamp("2017-06-05", tz=TIMEZONE),
+        pd.Timestamp("2017-12-25", tz=TIMEZONE),
+        pd.Timestamp("2017-12-26", tz=TIMEZONE)
+    ]
+
+    half_trading_days_2017 = [
+        pd.Timestamp("2017-04-12", tz=TIMEZONE)
+    ]
+
+    valid_market_dates = ose.valid_days("2017-01-01", "2017-12-31", tz=TIMEZONE)
+
+    for closed_market_date in regular_holidays_2017:
+        assert closed_market_date not in valid_market_dates
+
+    for half_trading_day in half_trading_days_2017:
+        assert half_trading_day in valid_market_dates
+
+    assert ose.open_at_time(
+        schedule=ose_schedule,
+        timestamp=pd.Timestamp("2017-04-12 12PM", tz=TIMEZONE)
+    )
+
+    assert not ose.open_at_time(
+        schedule=ose_schedule,
+        timestamp=pd.Timestamp("2017-04-12 2PM", tz=TIMEZONE)
+    )
+
+
+def test_2018_calendar():
+    ose = OSEExchangeCalendar()
+    ose_schedule = ose.schedule(
+        start_date=pd.Timestamp("2018-03-27", tz=TIMEZONE),
+        end_date=pd.Timestamp("2018-03-29", tz=TIMEZONE)
+    )
+
+    regular_holidays_2018 = [
+        pd.Timestamp("2018-01-01", tz=TIMEZONE),
+        pd.Timestamp("2018-03-29", tz=TIMEZONE),
+        pd.Timestamp("2018-03-30", tz=TIMEZONE),
+        pd.Timestamp("2018-05-01", tz=TIMEZONE),
+        pd.Timestamp("2018-05-10", tz=TIMEZONE),
+        pd.Timestamp("2018-05-17", tz=TIMEZONE),
+        pd.Timestamp("2018-05-21", tz=TIMEZONE),
+        pd.Timestamp("2018-12-24", tz=TIMEZONE),
+        pd.Timestamp("2018-12-25", tz=TIMEZONE),
+        pd.Timestamp("2018-12-26", tz=TIMEZONE),
+        pd.Timestamp("2018-12-31", tz=TIMEZONE)
+    ]
+
+    half_trading_days_2018 = [
+        pd.Timestamp("2018-03-28", tz=TIMEZONE)
+    ]
+
+    valid_market_dates = ose.valid_days("2018-01-01", "2018-12-31", tz=TIMEZONE)
+
+    for closed_market_date in regular_holidays_2018:
+        assert closed_market_date not in valid_market_dates
+
+    for half_trading_day in half_trading_days_2018:
+        assert half_trading_day in valid_market_dates
+
+    assert ose.open_at_time(
+        schedule=ose_schedule,
+        timestamp=pd.Timestamp("2018-03-28 12PM", tz=TIMEZONE)
+    )
+
+    assert not ose.open_at_time(
+        schedule=ose_schedule,
+        timestamp=pd.Timestamp("2018-03-28 1:10PM", tz=TIMEZONE)
+    )
+
+
+def test_2019_calendar():
+    ose = OSEExchangeCalendar()
+    ose_schedule = ose.schedule(
+        start_date=pd.Timestamp("2019-04-16", tz=TIMEZONE),
+        end_date=pd.Timestamp("2019-04-18", tz=TIMEZONE)
+    )
+
+    regular_holidays_2019 = [
+        pd.Timestamp("2019-01-01", tz=TIMEZONE),
+        pd.Timestamp("2019-04-18", tz=TIMEZONE),
+        pd.Timestamp("2019-04-19", tz=TIMEZONE),
+        pd.Timestamp("2019-04-22", tz=TIMEZONE),
+        pd.Timestamp("2019-05-01", tz=TIMEZONE),
+        pd.Timestamp("2019-05-17", tz=TIMEZONE),
+        pd.Timestamp("2019-05-30", tz=TIMEZONE),
+        pd.Timestamp("2019-06-10", tz=TIMEZONE),
+        pd.Timestamp("2019-12-24", tz=TIMEZONE),
+        pd.Timestamp("2019-12-25", tz=TIMEZONE),
+        pd.Timestamp("2019-12-26", tz=TIMEZONE),
+        pd.Timestamp("2019-12-31", tz=TIMEZONE)
+    ]
+
+    half_trading_days_2019 = [
+        pd.Timestamp("2019-04-17", tz=TIMEZONE)
+    ]
+
+    valid_market_dates = ose.valid_days("2019-01-01", "2019-12-31", tz=TIMEZONE)
+
+    for closed_market_date in regular_holidays_2019:
+        assert closed_market_date not in valid_market_dates
+
+    for half_trading_day in half_trading_days_2019:
+        assert half_trading_day in valid_market_dates
+
+    assert ose.open_at_time(
+        schedule=ose_schedule,
+        timestamp=pd.Timestamp("2019-04-17 12PM", tz=TIMEZONE)
+    )
+
+    assert not ose.open_at_time(
+        schedule=ose_schedule,
+        timestamp=pd.Timestamp("2019-04-17 1:10PM", tz=TIMEZONE)
+    )


### PR DESCRIPTION
Hey, so I implemented the Oslo Stock Exchange. Was only able to find the dates for 2017, 2018 and 2019 for validation. 

Appreciate any feedback.

From commit message:
Oslo Stock Exchange holiday calendar. The trading times are for the equities (other instruments have other opening/closing times).
I can only find dates for 2017, 2018 and 2019 for now, but will see if anyone can supplement me with the ones for the last decade.
Unit tests are passing.
Documents updated and removed unused (jpx\_autumnal\_equinox module).
Removed unused imports