### PR TITLE
Add GHW Bush Day of Mourning (2018-12-5, NYSE)

### DIFF
--- a/pandas_market_calendars/calendar_registry.py
+++ b/pandas_market_calendars/calendar_registry.py
@@ -1,16 +1,5 @@
 
 from .market_calendar import MarketCalendar
-from .exchange_calendar_cfe import CFEExchangeCalendar	
-from .exchange_calendar_ice import ICEExchangeCalendar	
-from .exchange_calendar_nyse import NYSEExchangeCalendar	
-from .exchange_calendar_cme import CMEExchangeCalendar	
-from .exchange_calendar_bmf import BMFExchangeCalendar	
-from .exchange_calendar_lse import LSEExchangeCalendar	
-from .exchange_calendar_tsx import TSXExchangeCalendar	
-from .exchange_calendar_eurex import EUREXExchangeCalendar	
-from .exchange_calendar_six import SIXExchangeCalendar	
-from .exchange_calendar_jpx import JPXExchangeCalendar
-from .exchange_calendar_ose import OSEExchangeCalendar
 
 def get_calendar(name, open_time=None, close_time=None):
     """

--- a/pandas_market_calendars/calendar_registry.py
+++ b/pandas_market_calendars/calendar_registry.py
@@ -1,6 +1,7 @@
 
 from .market_calendar import MarketCalendar
 
+
 def get_calendar(name, open_time=None, close_time=None):
     """
     Retrieves an instance of an MarketCalendar whose name is given.

--- a/pandas_market_calendars/calendar_registry.py
+++ b/pandas_market_calendars/calendar_registry.py
@@ -1,6 +1,16 @@
 
 from .market_calendar import MarketCalendar
-
+from .exchange_calendar_cfe import CFEExchangeCalendar	
+from .exchange_calendar_ice import ICEExchangeCalendar	
+from .exchange_calendar_nyse import NYSEExchangeCalendar	
+from .exchange_calendar_cme import CMEExchangeCalendar	
+from .exchange_calendar_bmf import BMFExchangeCalendar	
+from .exchange_calendar_lse import LSEExchangeCalendar	
+from .exchange_calendar_tsx import TSXExchangeCalendar	
+from .exchange_calendar_eurex import EUREXExchangeCalendar	
+from .exchange_calendar_six import SIXExchangeCalendar	
+from .exchange_calendar_jpx import JPXExchangeCalendar
+from .exchange_calendar_ose import OSEExchangeCalendar
 
 def get_calendar(name, open_time=None, close_time=None):
     """

--- a/pandas_market_calendars/exchange_calendar_nyse.py
+++ b/pandas_market_calendars/exchange_calendar_nyse.py
@@ -150,6 +150,7 @@ class NYSEExchangeCalendar(MarketCalendar):
     - Closed on 6/11/2004 due to Ronald Reagan's death.
     - Closed on 1/2/2007 due to Gerald Ford's death.
     - Closed on 10/29/2012 and 10/30/2012 due to Hurricane Sandy.
+    - Closed on 12/5/2018 due to George H.W. Bush's death.
     - Closed at 1:00 PM on Wednesday, July 3rd, 2013
     - Closed at 1:00 PM on Friday, December 31, 1999
     - Closed at 1:00 PM on Friday, December 26, 1997

--- a/pandas_market_calendars/us_holidays.py
+++ b/pandas_market_calendars/us_holidays.py
@@ -346,6 +346,7 @@ HurricaneSandyClosings = date_range(
 # - President Richard Nixon - April 27, 1994
 # - President Ronald W. Reagan - June 11, 2004
 # - President Gerald R. Ford - Jan 2, 2007
+# - President George H.W. Bush - Dec 5, 2018
 USNationalDaysofMourning = [
     Timestamp('1963-11-25', tz='UTC'),
     Timestamp('1968-04-09', tz='UTC'),
@@ -355,4 +356,5 @@ USNationalDaysofMourning = [
     Timestamp('1994-04-27', tz='UTC'),
     Timestamp('2004-06-11', tz='UTC'),
     Timestamp('2007-01-02', tz='UTC'),
+    Timestamp('2018-12-05', tz='UTC'),
 ]


### PR DESCRIPTION
This is the PR #53 without the addition of the imports in the calendar_registry.py file which are not needed.