### PR TITLE
add JPX Ascension Day holidays for 2019

### DIFF
--- a/pandas_market_calendars/exchange_calendar_jpx.py
+++ b/pandas_market_calendars/exchange_calendar_jpx.py
@@ -7,6 +7,7 @@ from pytz import timezone
 
 from pandas.tseries.holiday import AbstractHolidayCalendar
 from pandas_market_calendars.holidays_us import USNewYearsDay
+from pandas_market_calendars.holidays_jp import AscensionDays
 
 from pandas_market_calendars import MarketCalendar
 from pandas_market_calendars.jpx_equinox import autumnal_equinox, vernal_equinox
@@ -42,6 +43,9 @@ class JPXExchangeCalendar(MarketCalendar):
     def close_time_default(self):
         return time(15, tzinfo=self.tz)
 
+    @property
+    def adhoc_holidays(self):
+        return list(AscensionDays)
     @property
     def regular_holidays(self):
         return AbstractHolidayCalendar(rules=[

--- a/pandas_market_calendars/holidays_jp.py
+++ b/pandas_market_calendars/holidays_jp.py
@@ -1,0 +1,17 @@
+from pandas import (
+    Timestamp
+)
+
+# Apr. 30 (Tue.)    Abdication Day
+# May 1 (Wed.)    Accession Day
+# May 2 (Thu.)    National Holiday
+# May 3 (Fri.)    Constitution Memorial Day
+# May 4 (Sat.)    Greenery Day
+# May 6 (Mon.)    Children's Day (May 5) observed
+AscensionDays = [
+    Timestamp('2019-04-30', tz='Asia/Tokyo'),
+    Timestamp('2019-05-01', tz='Asia/Tokyo'),
+    Timestamp('2019-05-02', tz='Asia/Tokyo'),
+    Timestamp('2019-05-03', tz='Asia/Tokyo'),
+    Timestamp('2019-05-06', tz='Asia/Tokyo'),
+]

--- a/tests/test_jpx_calendar.py
+++ b/tests/test_jpx_calendar.py
@@ -76,6 +76,9 @@ def test_all_holidays():
         pd.Timestamp("2019-02-11", tz='UTC'),
         pd.Timestamp("2019-03-21", tz='UTC'),
         pd.Timestamp("2019-04-29", tz='UTC'),
+        pd.Timestamp("2019-04-30", tz='UTC'),
+        pd.Timestamp("2019-05-01", tz='UTC'),
+        pd.Timestamp("2019-05-02", tz='UTC'),
         pd.Timestamp("2019-05-03", tz='UTC'),
         pd.Timestamp("2019-05-04", tz='UTC'),
         pd.Timestamp("2019-05-06", tz='UTC'),
@@ -142,4 +145,4 @@ def test_jpx_correctly_counts_jpx_vernal_equinox():
     assert pd.Timestamp('2018-03-21') not in jpx_schedule.index
 
     assert pd.Timestamp('2019-03-21') not in jpx_schedule.index
-    assert pd.Timestamp('2019-03-20') in jpx_schedule.index  
+    assert pd.Timestamp('2019-03-20') in jpx_schedule.index


### PR DESCRIPTION
Japan did a 10 day holiday to mark the ascension of the new emperor