### PR TITLE
added german national holiday

### DIFF
--- a/pandas_market_calendars/exchange_calendar_eurex.py
+++ b/pandas_market_calendars/exchange_calendar_eurex.py
@@ -37,6 +37,13 @@ MayBank = Holiday(
     day=1,
     days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
 )
+# German National Holiday (Tag der Deutschen Einheit)
+GermanNationalDay = Holdiay(
+    'Tag der Deutschen Einheit',
+    month=10,
+    day=3,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
+)
 # Christmas Eve
 ChristmasEve = Holiday(
     'Christmas Eve',

--- a/pandas_market_calendars/exchange_calendar_eurex.py
+++ b/pandas_market_calendars/exchange_calendar_eurex.py
@@ -112,6 +112,7 @@ class EUREXExchangeCalendar(MarketCalendar):
             GoodFriday,
             EasterMonday,
             MayBank,
+            GermanNationalDay,
             Christmas,
             WeekendChristmas,
             BoxingDay,

--- a/pandas_market_calendars/exchange_calendar_eurex.py
+++ b/pandas_market_calendars/exchange_calendar_eurex.py
@@ -38,7 +38,7 @@ MayBank = Holiday(
     days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
 )
 # German National Holiday (Tag der Deutschen Einheit)
-GermanNationalDay = Holdiay(
+GermanNationalDay = Holiday(
     'Tag der Deutschen Einheit',
     month=10,
     day=3,


### PR DESCRIPTION
ETF and ETC based on Xetra: trading and exercise closed
german equity index options: trading and exercise closed (e.g. ODAX)
german equity index futures: are trading (e.g. FDAX)
german interest rate derivatives are trading (e.g. FGBM)
derivatives with underlying having its primary listing outside germany are trading (e.g. KOSPI)

https://www.eurexchange.com/exchange-en/trading/trading-calendar/holiday-regulations