### PR TITLE
Add timezone functionality to schedule()

### DIFF
--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -8,7 +8,8 @@ Updates
 - Add the concept of a break during the trading day. For example this can accommodate Asian markets that have a lunch
 break, or futures markets that are open 24 hours with a break in the day for trade processing.
 - Added product specific contract calendars for CME futures exchange
-- First calendar is the CME Agricultural calendar
+-- First calendar is the CME Agricultural calendar
+- Add ability to set time zone on schedule() function #42
 - Add the Bombay exchange (XBOM) from #96
 - Fixed Christmas holidays in SIX #100
 

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -229,15 +229,16 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         """
         return pd.date_range(start_date, end_date, freq=self.holidays(), normalize=True, tz=tz)
 
-    def schedule(self, start_date, end_date):
+    def schedule(self, start_date, end_date, tz='UTC'):
         """
         Generates the schedule DataFrame. The resulting DataFrame will have all the valid business days as the index
         and columns for the market opening datetime (market_open) and closing datetime (market_close). All time zones
-        are set to UTC. To convert to the local market time use pandas tz_convert and the self.tz to get the
-        market time zone.
+        are set to UTC by default. Setting the tz parameter will convert the columns to the desired timezone, 
+        such as 'America/New_York'
 
         :param start_date: start date
         :param end_date: end date
+        :param tz: timezone
         :return: schedule DataFrame
         """
         start_date, end_date = clean_dates(start_date, end_date)
@@ -252,8 +253,8 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             return pd.DataFrame(columns=['market_open', 'market_close'], index=pd.DatetimeIndex([], freq='C'))
 
         # `DatetimeIndex`s of standard opens/closes for each day.
-        opens = days_at_time(_all_days, self.open_time, self.tz, self.open_offset)
-        closes = days_at_time(_all_days, self.close_time, self.tz, self.close_offset)
+        opens = days_at_time(_all_days, self.open_time, self.tz, self.open_offset).tz_convert(tz)
+        closes = days_at_time(_all_days, self.close_time, self.tz, self.close_offset).tz_convert(tz)
 
         # `DatetimeIndex`s of nonstandard opens/closes
         _special_opens = self._calculate_special_opens(start_date, end_date)
@@ -267,10 +268,10 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
                          data={'market_open': opens, 'market_close': closes})
         
         if self.break_start:
-            result['break_start'] = days_at_time(_all_days, self.break_start, self.tz)
+            result['break_start'] = days_at_time(_all_days, self.break_start, self.tz).tz_convert(tz)
             temp = result[['market_open', 'break_start']].max(axis=1)
             result['break_start'] = temp
-            result['break_end'] = days_at_time(_all_days, self.break_end, self.tz)
+            result['break_end'] = days_at_time(_all_days, self.break_end, self.tz).tz_convert(tz)
             temp = result[['market_close', 'break_end']].min(axis=1)
             result['break_end'] = temp
             

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -239,6 +239,15 @@ def test_schedule():
     # start date after end date
     with pytest.raises(ValueError):
         cal.schedule('2016-02-02', '2016-01-01')
+    
+    # using a different time zone
+    expected = pd.DataFrame({'market_open': pd.Timestamp('2016-11-30 22:13:00-05:00', tz='US/Eastern', freq='B'),
+                             'market_close': pd.Timestamp('2016-11-30 22:49:00-05:00', tz='US/Eastern', freq='B')},
+                            index=pd.DatetimeIndex([pd.Timestamp('2016-12-01')]),
+                            columns=['market_open', 'market_close'])
+
+    actual = cal.schedule('2016-12-01', '2016-12-01', tz='US/Eastern')
+    assert_frame_equal(actual, expected)
 
 
 def test_schedule_w_breaks():
@@ -294,6 +303,17 @@ def test_schedule_w_breaks():
                          'break_end'])
 
     assert_series_equal(results.iloc[-1], expected)
+
+    # using a different time zone
+    expected = pd.DataFrame({'market_open': pd.Timestamp('2016-12-28 09:30:00-05:00', tz='America/New_York', freq='B'),
+                             'market_close': pd.Timestamp('2016-12-28 12:00:00-05:00', tz='America/New_York', freq='B'),
+                             'break_start': pd.Timestamp('2016-12-28 10:00:00-05:00', tz='America/New_York', freq='B'),
+                             'break_end': pd.Timestamp('2016-12-28 11:00:00-05:00', tz='America/New_York', freq='B')},
+                            index=pd.DatetimeIndex([pd.Timestamp('2016-12-28')]),
+                            columns=['market_open', 'market_close', 'break_start', 'break_end'])
+
+    actual = cal.schedule('2016-12-28', '2016-12-28', tz='America/New_York')
+    assert_frame_equal(actual, expected)
 
 
 def test_schedule_w_times():


### PR DESCRIPTION
This is finally addressing issue #42. The idea is to supply a timezone to schedule() in order to convert open/close times to a certain timezone, like US/Eastern. I figured instead of using an if/else block, we could just convert the timezone directly on the open/close dataframes even though this may be a tiny bit of extra compute overhead for the default UTC.