### PR TITLE
#87 Add is open now

### DIFF
--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -306,6 +306,26 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         else:
             return False
 
+    # need this to make is_open_now testable
+    @staticmethod
+    def _get_current_time():
+        return pd.Timestamp.now(tz='UTC')
+
+    @staticmethod
+    def is_open_now(schedule, include_close=False):
+        """
+        To determine if the current local system time (converted to UTC) is an open time for the market
+
+        :param schedule: schedule DataFrame
+        :param include_close: if False then the function will return False if the current local system time is equal to
+            the closing timestamp. If True then it will return True if the current local system time is equal to the
+            closing timestamp. Use True if using bars and would like to include the last bar as a valid open date
+            and time.
+        :return: True if the current local system time is a valid open date and time, False if not
+        """
+        current_time = MarketCalendar._get_current_time()
+        return MarketCalendar.open_at_time(schedule, current_time)
+
     def early_closes(self, schedule):
         """
         Get a DataFrame of the dates that are an early close.

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -108,6 +108,13 @@ class FakeBreakCalendar(MarketCalendar):
         return [(time(10, 40), ['2016-12-30'])]
 
 
+@pytest.fixture
+def patch_get_current_time(monkeypatch):
+    def get_fake_time():
+        return pd.Timestamp('2014-07-02 03:40', tz='UTC')
+    monkeypatch.setattr(MarketCalendar, '_get_current_time', get_fake_time)
+
+
 def test_default_calendars():
     for name in get_calendar_names():
         assert get_calendar(name) is not None
@@ -497,6 +504,14 @@ def test_open_at_time_breaks():
     assert cal.open_at_time(schedule, pd.Timestamp('2016-12-28 11:00', tz='America/New_York')) is True
     # between break and close
     assert cal.open_at_time(schedule, pd.Timestamp('2016-12-28 11:30', tz='America/New_York')) is True
+
+
+def test_is_open_now(patch_get_current_time):
+    cal = FakeCalendar()
+
+    schedule = cal.schedule('2014-01-01', '2016-12-31')
+
+    assert cal.is_open_now(schedule) is True
 
 
 def test_bad_dates():


### PR DESCRIPTION
'MarketCalendar._get_current_time' uses UTC time because 'MarketCalendar.schedule' is currently based on UTC time 'Market.Calendar.valid_days'.

IMO this justifies the elaborate mock test case (can't find a better way to mock system time) - as it can serve as a basis to create similar tests later on.