### PR TITLE
open_at_time fix

### DIFF
--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -548,7 +548,8 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
     def open_at_time(self, schedule, timestamp, include_close=False, only_rth= False):
         """
-        To determine if a given timestamp is during an open time for the market.
+        To determine if a given timestamp is during an open time for the market. If the timestamp is
+        before the first open time or after the last close time of `schedule`, a ValueError will be raised.
 
         :param schedule: schedule DataFrame
         :param timestamp: the timestamp to check for

--- a/tests/test_bse_calendar.py
+++ b/tests/test_bse_calendar.py
@@ -1,5 +1,5 @@
 import datetime
-
+import pytest
 import pandas as pd
 import pytz
 
@@ -33,7 +33,8 @@ def test_open_close_time():
         timestamp=india_time_zone.localize(datetime.datetime(2015, 1, 14, 11, 0))
     )
 
-    assert not bse_calendar.open_at_time(
+    with pytest.raises(ValueError):
+        bse_calendar.open_at_time(
         schedule=bse_schedule,
         timestamp=india_time_zone.localize(datetime.datetime(2015, 1, 9, 12, 0))
     )

--- a/tests/test_ose_calendar.py
+++ b/tests/test_ose_calendar.py
@@ -8,6 +8,7 @@
 """
 
 import pandas as pd
+import pytest
 import pytz
 
 from pandas_market_calendars.exchange_calendar_ose import OSEExchangeCalendar
@@ -68,8 +69,8 @@ def test_2017_calendar():
         schedule=ose_schedule,
         timestamp=pd.Timestamp("2017-04-12 12PM", tz=TIMEZONE)
     )
-
-    assert not ose.open_at_time(
+    with pytest.raises(ValueError):
+        ose.open_at_time(
         schedule=ose_schedule,
         timestamp=pd.Timestamp("2017-04-12 2PM", tz=TIMEZONE)
     )
@@ -112,8 +113,8 @@ def test_2018_calendar():
         schedule=ose_schedule,
         timestamp=pd.Timestamp("2018-03-28 12PM", tz=TIMEZONE)
     )
-
-    assert not ose.open_at_time(
+    with pytest.raises(ValueError):
+        ose.open_at_time(
         schedule=ose_schedule,
         timestamp=pd.Timestamp("2018-03-28 1:10PM", tz=TIMEZONE)
     )
@@ -157,8 +158,8 @@ def test_2019_calendar():
         schedule=ose_schedule,
         timestamp=pd.Timestamp("2019-04-17 12PM", tz=TIMEZONE)
     )
-
-    assert not ose.open_at_time(
+    with pytest.raises(ValueError):
+        ose.open_at_time(
         schedule=ose_schedule,
         timestamp=pd.Timestamp("2019-04-17 1:10PM", tz=TIMEZONE)
     )


### PR DESCRIPTION
This would be my proposed solution for #164, including an update to the tests.

@rsheftel, I think that it would be better to raise an error if a timestamp is passed that falls outside of the range covered by the schedule instead of returning False. Some tests are failing because I already implemented that. I wanted to see if you agree before adjusting those tests?

Thanks