### PR TITLE
Fix deprecation warning with pandas 1.4.0

### DIFF
--- a/pandas_market_calendars/exchange_calendar_nyse.py
+++ b/pandas_market_calendars/exchange_calendar_nyse.py
@@ -965,36 +965,44 @@ class NYSEExchangeCalendar(MarketCalendar):
 #
     @property
     def special_closes_adhoc(self):
+        def _union_many(indexes):
+            # Merges a list of pd.DatetimeIndex objects, returns merged DatetimeIndex
+            union_index = pd.DatetimeIndex([], tz="UTC")
+            for index in indexes:
+                union_index = union_index.union(index)
+            return union_index
+
         return [
             (time(13, tzinfo=timezone('America/New_York')),
-              DaysBeforeIndependenceDay1pmEarlyCloseAdhoc # list
+                DaysBeforeIndependenceDay1pmEarlyCloseAdhoc # list
                 + ChristmasEve1pmEarlyCloseAdhoc
                 + DayAfterChristmas1pmEarlyCloseAdhoc
                 + BacklogRelief1pmEarlyClose1929
             ),
-            (time(14, tzinfo=timezone('America/New_York')), pd.DatetimeIndex(
+            (time(14, tzinfo=timezone('America/New_York')), _union_many(
+                [pd.DatetimeIndex(
                  ChristmasEve2pmEarlyCloseAdhoc
-                 + HeavyVolume2pmEarlyClose1933
-                        ).union_many([
-                 BacklogRelief2pmEarlyClose1928,
+                 + HeavyVolume2pmEarlyClose1933)] +
+                                      
+                [BacklogRelief2pmEarlyClose1928,
                  TransitStrike2pmEarlyClose1966, # index
                  Backlog2pmEarlyCloses1967, # index
                  Backlog2pmEarlyCloses1968, # index
                  PaperworkCrisis2pmEarlyCloses1969, # index
                  Backlog2pmEarlyCloses1987 ])# index
             ),
-            (time(14, 30, tzinfo=timezone('America/New_York')), pd.DatetimeIndex([], tz= "UTC"
-                        ).union_many([
-                PaperworkCrisis230pmEarlyCloses1969,
-                Backlog230pmEarlyCloses1987]) # index
+            (time(14, 30, tzinfo=timezone('America/New_York')), _union_many(
+                                      
+                [PaperworkCrisis230pmEarlyCloses1969,
+                 Backlog230pmEarlyCloses1987]) # index
             ),
-            (time(15, tzinfo=timezone('America/New_York')), pd.DatetimeIndex([], tz= "UTC"
-                        ).union_many([
-                PaperworkCrisis3pmEarlyCloses1969to1970,
-                Backlog3pmEarlyCloses1987]) # index
+            (time(15, tzinfo=timezone('America/New_York')), _union_many(
+                                      
+                [PaperworkCrisis3pmEarlyCloses1969to1970,
+                 Backlog3pmEarlyCloses1987]) # index
             ),
             (time(15, 30, tzinfo=timezone('America/New_York')),
-                Backlog330pmEarlyCloses1987 # idnex
+                Backlog330pmEarlyCloses1987 # index
             ),
         ]
 

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -429,13 +429,18 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
         (This is shared logic for computing special opens and special closes.)
         """
-        dates = pd.DatetimeIndex([], tz= "UTC").union_many(
-            [
+        indexes = ([
                 self.days_at_time(self._tryholidays(calendar, start, end), time_)
                       for time_, calendar in calendars
              ] + [
                 self.days_at_time(dates, time_) for time_, dates in ad_hoc_dates
             ])
+        if len(indexes):
+            dates = indexes[0]
+            for index in indexes[1:]:
+                dates = dates.union(index)
+        else:
+            dates = pd.DatetimeIndex([], tz="UTC")
 
         start = start.tz_localize("UTC")
         end = end.tz_localize("UTC").replace(hour=23, minute=59, second=59)


### PR DESCRIPTION
DatetimeIndex.union_many() is deprecated as of pandas 1.4.0. This PR replaces union_many() in [market_calendar.py](https://github.com/rsheftel/pandas_market_calendars/blob/master/pandas_market_calendars/market_calendar.py) and [exchange_calendar_nyse.py](https://github.com/rsheftel/pandas_market_calendars/blob/master/pandas_market_calendars/exchange_calendar_nyse.py).

Tests now run without warning. Closes #168