### PR TITLE
Fix the date for Australia Day

### DIFF
--- a/pandas_market_calendars/holidays_oz.py
+++ b/pandas_market_calendars/holidays_oz.py
@@ -17,7 +17,7 @@ OZNewYearsDay = Holiday(
 AustraliaDay = Holiday(
     "Australia Day",
     month=1,
-    day=27,
+    day=26,
     observance=weekend_to_monday,
 )
 


### PR DESCRIPTION
Looks like a typo slipped into the holiday calendar for Australia. Australia Day should be on 26 January, not 27. This fixes the typo.

Context: https://info.australia.gov.au/about-australia/special-dates-and-events/public-holidays