### PR TITLE
Fix calculation of Boxing Day additional day for Australia, add tests

### DIFF
--- a/pandas_market_calendars/exchange_calendar_asx.py
+++ b/pandas_market_calendars/exchange_calendar_asx.py
@@ -54,7 +54,6 @@ class ASXExchangeCalendar(MarketCalendar):
 			QueensBirthday,
 			Christmas,
 			BoxingDay,
-			WeekendBoxingDay,
 			GoodFriday,
 			EasterMonday,
 		])

--- a/pandas_market_calendars/holidays_oz.py
+++ b/pandas_market_calendars/holidays_oz.py
@@ -1,9 +1,12 @@
 # OZ Holidays
 
 from pandas import DateOffset
-from pandas.tseries.holiday import Holiday, MO, weekend_to_monday
-
-from pandas_market_calendars.market_calendar import MONDAY, TUESDAY
+from pandas.tseries.holiday import (
+    Holiday,
+    MO,
+    next_monday_or_tuesday,
+    weekend_to_monday,
+)
 
 # New Year's Day
 OZNewYearsDay = Holiday(
@@ -50,13 +53,5 @@ BoxingDay = Holiday(
     "Boxing Day",
     month=12,
     day=26,
-)
-
-# If boxing day is saturday then Monday 28th is a holiday
-# If boxing day is sunday then Tuesday 28th is a holiday
-WeekendBoxingDay = Holiday(
-    "Weekend Boxing Day",
-    month=12,
-    day=28,
-    days_of_week=(MONDAY, TUESDAY),
+    observance=next_monday_or_tuesday,
 )

--- a/tests/test_asx_calendar.py
+++ b/tests/test_asx_calendar.py
@@ -1,0 +1,36 @@
+import pytz
+import pandas as pd
+
+from pandas_market_calendars.exchange_calendar_asx import ASXExchangeCalendar
+
+
+def test_time_zone():
+    assert ASXExchangeCalendar().tz == pytz.timezone('Australia/Sydney')
+
+
+def test_2019_holidays():
+    # 2019/01/28 - Australia Day (additional day)
+    asx = ASXExchangeCalendar()
+    good_dates = asx.valid_days('2019-01-01', '2019-12-31')
+    for date in ["2019-01-28"]:
+        assert pd.Timestamp(date, tz='UTC') not in good_dates
+
+
+def test_2021_holidays():
+    # 2021/01/26 - Australia Day
+    # 2021/12/27 - Christmas (additional day)
+    # 2021/12/28 - Boxing Day (additional day)
+    asx = ASXExchangeCalendar()
+    good_dates = asx.valid_days('2021-01-01', '2021-12-31')
+    for date in ["2021-01-26", "2021-12-27", "2021-12-28"]:
+        assert pd.Timestamp(date, tz='UTC') not in good_dates
+
+
+def test_2022_holidays():
+    # 2022/01/26 - Australia Day
+    # 2022/12/25 - Christmas
+    # 2022/12/26 - Boxing Day
+    asx = ASXExchangeCalendar()
+    good_dates = asx.valid_days('2022-01-01', '2022-12-31')
+    for date in ["2022-01-26", "2022-12-25", "2022-12-26"]:
+        assert pd.Timestamp(date, tz='UTC') not in good_dates


### PR DESCRIPTION
Used the correct rule to move Boxing Day to Tuesday when Christmas falls on a Saturday.

Closes #169

Reference: https://en.wikipedia.org/wiki/Public_holidays_in_Australia#:~:text=If%20Christmas%20Day%20(25%20December,is%20also%20a%20public%20holiday.