### PR TITLE
Added SIFMA US, UK, and JP Calendars

### DIFF
--- a/pandas_market_calendars/calendar_registry.py
+++ b/pandas_market_calendars/calendar_registry.py
@@ -13,6 +13,7 @@ from .exchange_calendar_jpx import JPXExchangeCalendar
 from .exchange_calendar_lse import LSEExchangeCalendar
 from .exchange_calendar_nyse import NYSEExchangeCalendar
 from .exchange_calendar_ose import OSEExchangeCalendar
+from .exchange_calendar_sifma import SIFMAUSExchangeCalendar, SIFMAUKExchangeCalendar, SIFMAJPExchangeCalendar
 from .exchange_calendar_six import SIXExchangeCalendar
 from .exchange_calendar_sse import SSEExchangeCalendar
 from .exchange_calendar_tsx import TSXExchangeCalendar

--- a/pandas_market_calendars/exchange_calendar_sifma.py
+++ b/pandas_market_calendars/exchange_calendar_sifma.py
@@ -1,0 +1,300 @@
+from datetime import time
+
+from pandas.tseries.holiday import AbstractHolidayCalendar
+from pytz import timezone
+from itertools import chain
+import pandas as pd
+
+
+########################################################################################################################
+# SIFMA Financial Markets Calendar for US, UK, JP
+#
+# https://www.sifma.com/
+#
+# US: SIFMAUSExchangeCalendar() ['SIFMAUS', 'SIFMA_US', "Capital_Markets_US", "Financial_Markets_US", "Bond_Markets_US"]
+# UK: SIFMAUKExchangeCalendar() ['SIFMAUK', 'SIFMA_UK', "Capital_Markets_UK", "Financial_Markets_UK", "Bond_Markets_UK"]
+# JP: SIFMAJPExchangeCalendar() ['SIFMAJP', 'SIFMA_JP', "Capital_Markets_JP", "Financial_Markets_JP", "Bond_Markets_JP"]
+# 
+# Trading Hours:
+# US: 7:00 to 17:30
+# UK: 8:00 to 17:00
+# JP: 8:30 to 18:30
+########################################################################################################################
+
+
+from pandas_market_calendars.holidays_sifma import(
+    # US Holidays
+    UKWeekendBoxingDay,
+    USNewYearsDay,  # Not observed if a Saturday
+    USNewYearsEve2pmEarlyClose,
+
+    MartinLutherKingJr,
+    USPresidentsDay,
+  
+    GoodFridayThru2020,
+    DayBeforeGoodFriday2pmEarlyCloseThru2020,
+    GoodFridayAdHoc,
+    GoodFriday2pmEarlyCloseAdHoc,
+    DayBeforeGoodFriday2pmEarlyCloseAdHoc,
+
+    DayBeforeUSMemorialDay2pmEarlyClose,
+    USMemorialDay,
+    USJuneteenthAfter2022,
+
+    USIndependenceDay,
+    DayBeforeUSIndependenceDay2pmEarlyClose,
+    ThursdayBeforeUSIndependenceDay2pmEarlyClose,
+     
+    USLaborDay,
+    USColumbusDay,
+    USVeteransDay,
+    USThanksgivingDay,
+    DayAfterThanksgiving2pmEarlyClose,
+
+    Christmas,
+    ChristmasEve2pmEarlyClose,
+    ChristmasEveThursday2pmEarlyClose,
+
+    # UK Specific Holidays
+    UKNewYearsDay,  # Saturdays observed on Monday
+    UKGoodFriday,
+    UKEasterMonday,
+    UKMayDay,
+    UKSpringBankAdHoc,  # Usually follows US Memorial Day but not always
+    UKSummerBank,
+    UKChristmas,
+    UKChristmaEve,
+    UKWeekendChristmas,  # Observed Tuesday when Boxing Day is on Monday
+    UKBoxingDay,
+    UKWeekendBoxingDay, 
+
+    UKPlatinumJubilee2022,
+)
+
+from .market_calendar import MarketCalendar
+
+#AbstractHolidayCalendar.start_date = '1998-01-01'   
+
+############################################################
+# US
+############################################################
+
+class SIFMAUSExchangeCalendar(MarketCalendar):
+    """
+    Exchange calendar for SIFMA United States
+
+    https://www.sifma.org/resources/general/holiday-schedule/#US
+
+    """
+ 
+    aliases = ['SIFMAUS', 'SIFMA_US', "Capital_Markets_US", "Financial_Markets_US", "Bond_Markets_US"]
+ 
+    regular_market_times = {
+        "market_open": ((None, time(7)),),
+        "market_close": ((None, time(17, 30)),)
+    }
+ 
+
+    @property
+    def name(self):
+        return "SIFMA_US"
+
+    @property
+    def tz(self):
+        return timezone("America/New_York")
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            USNewYearsDay,    
+            MartinLutherKingJr,
+            USPresidentsDay,
+            GoodFridayThru2020,
+            USMemorialDay,
+            USJuneteenthAfter2022,
+            USIndependenceDay,
+            USLaborDay,
+            USColumbusDay,
+            USVeteransDay,
+            USThanksgivingDay,
+            Christmas,
+         ])
+
+    @property
+    def adhoc_holidays(self):
+        return list(chain(
+            GoodFridayAdHoc,
+        ))
+
+
+
+    @property
+    def special_closes(self):
+        return [(
+            time(14),
+            AbstractHolidayCalendar(rules=[
+                DayBeforeGoodFriday2pmEarlyCloseThru2020,
+                DayBeforeUSMemorialDay2pmEarlyClose,
+                DayBeforeUSIndependenceDay2pmEarlyClose,
+                ThursdayBeforeUSIndependenceDay2pmEarlyClose,
+                DayAfterThanksgiving2pmEarlyClose,
+                ChristmasEve2pmEarlyClose,
+                ChristmasEveThursday2pmEarlyClose,
+                USNewYearsEve2pmEarlyClose,
+            ])
+        )]
+
+    @property
+    def special_closes_adhoc(self):
+        return [
+            (time(14, tzinfo=timezone('America/New_York')),
+                GoodFriday2pmEarlyCloseAdHoc # list
+                + DayBeforeGoodFriday2pmEarlyCloseAdHoc
+            ),
+        ]
+
+############################################################
+# UK
+############################################################
+
+class SIFMAUKExchangeCalendar(MarketCalendar):
+    """
+    Exchange calendar for SIFMA United Kingdom
+
+    https://www.sifma.org/resources/general/holiday-schedule/#UK
+
+    """
+ 
+    aliases = ['SIFMAUK', 'SIFMA_UK', "Capital_Markets_UK", "Financial_Markets_UK", "Bond_Markets_UK"]
+ 
+    regular_market_times = {
+        "market_open": ((None, time(8)),),
+        "market_close": ((None, time(17)),)
+    }
+
+    @property
+    def name(self):
+        return "SIFMA_UK"
+
+    @property
+    def tz(self):
+        return timezone("Europe/London")
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            UKNewYearsDay,    
+            MartinLutherKingJr,
+            USPresidentsDay,
+            UKGoodFriday, 
+            UKEasterMonday,
+            UKMayDay,
+            USMemorialDay,
+            USJuneteenthAfter2022,
+            USIndependenceDay,
+            UKSummerBank,
+            USLaborDay,
+            USColumbusDay,
+            USVeteransDay,
+            USThanksgivingDay,
+            UKChristmas,
+            UKChristmaEve,
+            UKWeekendChristmas,                    
+            UKBoxingDay,
+            UKWeekendBoxingDay
+        ])
+
+    @property
+    def adhoc_holidays(self):
+        return list(chain(
+            UKSpringBankAdHoc,
+            UKPlatinumJubilee2022, 
+         ))
+
+############################################################
+# Japan
+############################################################
+from .holidays_jp import (JapanComingOfAgeDay, JapanNationalFoundationDay,JapanEmperorsBirthday, JapanVernalEquinox,JapanShowaDay,
+                          JapanConstitutionMemorialDay, JapanGreeneryDay, JapanChildrensDay, JapanMarineDay, JapanMountainDay,
+                          JapanRespectForTheAgedDay, JapanAutumnalEquinox, 
+                          JapanHealthAndSportsDay2000To2019, JapanSportsDay2020, JapanSportsDay,
+                          JapanCultureDay, JapanLaborThanksgivingDay)
+
+class SIFMAJPExchangeCalendar(MarketCalendar):
+    """
+    Exchange calendar for SIFMA Japan
+
+    https://www.sifma.org/resources/general/holiday-schedule/#JP
+ 
+    """
+ 
+    aliases = ['SIFMAJP', 'SIFMA_JP', "Capital_Markets_JP", "Financial_Markets_JP", "Bond_Markets_JP"]
+ 
+    regular_market_times = {
+        "market_open": ((None, time(8, 30)),),
+        "market_close": ((None, time(18, 30)),)
+    } 
+
+    @property
+    def name(self):
+        return "SIFMA_JP"
+
+    @property
+    def tz(self):
+        return timezone("Asia/Tokyo")
+
+    @property
+    def regular_holidays(self):
+        return AbstractHolidayCalendar(rules=[
+            UKNewYearsDay,
+            JapanComingOfAgeDay,    
+            MartinLutherKingJr,
+            JapanNationalFoundationDay,
+            USPresidentsDay,
+            JapanEmperorsBirthday,
+            JapanVernalEquinox,
+            UKGoodFriday, 
+            UKEasterMonday,
+            JapanShowaDay,
+            JapanConstitutionMemorialDay,
+            JapanGreeneryDay,
+            JapanChildrensDay,
+            USMemorialDay,
+            USJuneteenthAfter2022,
+            USIndependenceDay,
+            JapanMarineDay,
+            JapanMountainDay,
+            UKSummerBank,
+            USLaborDay,
+            JapanRespectForTheAgedDay,
+            JapanAutumnalEquinox,
+            JapanSportsDay,
+            JapanSportsDay2020,
+            JapanHealthAndSportsDay2000To2019,
+            JapanCultureDay,
+            USVeteransDay,
+            JapanLaborThanksgivingDay,
+            USThanksgivingDay,
+            UKChristmas,
+            UKChristmaEve,
+            UKBoxingDay,
+            UKWeekendBoxingDay
+        ])
+
+    @property
+    def adhoc_holidays(self):
+        return list(chain(
+            UKSpringBankAdHoc,
+            UKPlatinumJubilee2022, 
+         ))
+
+    @property
+    def special_closes(self):
+        return [(
+            time(15),
+            AbstractHolidayCalendar(rules=[
+                UKMayDay,
+                UKWeekendChristmas                             
+            ])
+        )]
+

--- a/pandas_market_calendars/holidays_sifma.py
+++ b/pandas_market_calendars/holidays_sifma.py
@@ -1,0 +1,321 @@
+from dateutil.relativedelta import (MO, TH)
+from pandas import (DateOffset, Timestamp)
+from datetime import  timedelta
+from pandas.tseries.holiday import (Holiday, nearest_workday, next_monday, sunday_to_monday, 
+                                    previous_workday, Easter)
+from pandas.tseries.offsets import Day
+
+from pandas_market_calendars.market_calendar import ( MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
+
+
+####################################################
+# US New Years Day Jan 1
+# When Jan 1 is a Sunday, US markets observe the subsequent Monday.
+# When Jan 1 is a Saturday (as in 2005 and 2011), no holiday is observed.
+#####################################################
+USNewYearsDay = Holiday(
+    'New Years Day US',
+    month=1,
+    day=1,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY,),
+    observance=sunday_to_monday,
+ )
+
+USNewYearsEve2pmEarlyClose = Holiday(
+    'New Years Eve US',
+    month=1,
+    day=1,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY,),
+    observance = previous_workday,
+)
+
+#########################################################################
+# Martin Luther King Jr
+##########################################################################
+MartinLutherKingJr = Holiday(
+    'Dr. Martin Luther King Jr. Day',
+    month=1,
+    day=1,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY,),
+    offset=DateOffset(weekday=MO(3)),
+)
+
+#########################################################################
+# US Presidents Day Feb 
+##########################################################################
+USPresidentsDay = Holiday('President''s Day',
+                          start_date=Timestamp('1971-01-01'),
+                          month=2, day=1,
+                          days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY,),
+                          offset=DateOffset(weekday=MO(3)))
+
+
+############################################################
+# Good Friday 
+############################################################
+GoodFridayThru2020 = Holiday(
+    "Good Friday 1908+", 
+    end_date=Timestamp('2020-12-31'), 
+    month=1, 
+    day=1, 
+    offset=[Easter(), Day(-2)]
+)
+
+# 2021 is early close. 
+# 2022 is a full holiday. 
+# 2023 is early close.
+GoodFridayAdHoc = [Timestamp('2022-04-15', tz='UTC'),]
+
+GoodFriday2pmEarlyCloseAdHoc = [
+    Timestamp('2021-04-02', tz='UTC'),
+    Timestamp('2023-04-07', tz='UTC'),]
+
+
+DayBeforeGoodFriday2pmEarlyCloseThru2020 = Holiday(
+    "Day Before Good Friday Thru 2020",
+    end_date=Timestamp('2020-12-31'),
+    month=1,
+    day=1,
+    offset=[Easter(), Day(-3)]
+)
+
+DayBeforeGoodFriday2pmEarlyCloseAdHoc = [
+    Timestamp('2022-04-14', tz='UTC'),
+]
+
+##################################################
+# US Memorial Day (Decoration Day) May 30 
+#    Closed every year since 1873
+#    Observed on Monday since 1971
+##################################################
+USMemorialDay = Holiday(
+    'Memorial Day',
+    month=5,
+    day=25,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
+    offset=DateOffset(weekday=MO(1)),
+)
+
+DayBeforeUSMemorialDay2pmEarlyClose = Holiday(
+    'Day Before Memorial Day',
+    month=5,
+    day=25,
+    offset=[DateOffset(weekday=MO(1)), Day(-3)],
+)
+
+#######################################
+# US Juneteenth (June 19th)
+#######################################
+USJuneteenthAfter2022 = Holiday(
+    'Juneteenth Starting at 2022',
+    start_date=Timestamp('2022-06-19'),
+    month=6, day=19,
+    observance=nearest_workday,
+)
+
+#######################################
+# US Independence Day July 4
+#######################################
+USIndependenceDay = Holiday(
+    'July 4th',
+    month=7,
+    day=4,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
+    observance=nearest_workday,
+)
+
+# Day before Independence Day
+DayBeforeUSIndependenceDay2pmEarlyClose = Holiday(
+    'Day Before Independence Day',
+    month=7,
+    day=4,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
+    observance=previous_workday,
+)
+
+# When July 4th is a Saturday, the previous Friday is a holiday 
+# and the previous Thursday is an early close
+ThursdayBeforeUSIndependenceDay2pmEarlyClose = Holiday(
+    'Thursday Before Independence Day',
+    month=7,
+    day=2,
+    days_of_week=(THURSDAY,),
+)
+
+
+
+#################################################
+# US Labor Day 
+#################################################
+USLaborDay = Holiday(
+    "Labor Day", 
+    month=9, 
+    day=1, 
+    offset=DateOffset(weekday=MO(1))
+)
+
+
+#################################################
+# Columbus Day
+################################################# 
+USColumbusDay = Holiday(
+    'Columbus Day',
+    month=10,
+    day=1,
+    offset=DateOffset(weekday=MO(2)),
+)
+
+##########################################################
+# Armistice/Veterans day
+# When falls on Saturday, no holiday is observed.
+# When falls on Sunday, the Monday following is a holiday.
+##########################################################
+USVeteransDay = Holiday(
+    'Veterans Day',
+    month=11,
+    day=11,
+    end_date=Timestamp('2022-12-31'),
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
+    observance=sunday_to_monday,
+)
+
+################################################
+# US Thanksgiving Nov 30
+################################################
+USThanksgivingDay = Holiday(
+    'Thanksgiving',
+     month=11, day=1,
+    offset=DateOffset(weekday=TH(4))
+)
+
+
+DayAfterThanksgiving2pmEarlyClose = Holiday(
+    'Black Friday',
+    month=11,
+    day=1,
+     offset=[DateOffset(weekday=TH(4)), Day(1)],
+)
+
+
+
+################################
+# Christmas Dec 25
+################################
+Christmas = Holiday(
+    'Christmas',
+    month=12,
+    day=25,
+    observance=nearest_workday, 
+)
+
+ChristmasEve2pmEarlyClose = Holiday(
+    'Christmas Eve',
+    month=12,
+    day=25,
+    observance = previous_workday,
+ )
+
+# When Christmas is on a Saturday it is observed on Friday the 24th
+# Early close on Thursday 23rd
+ChristmasEveThursday2pmEarlyClose = Holiday(
+    'Christmas Eve on Thursday',
+    month=12,
+    day=23,
+    days_of_week=(THURSDAY,),
+)
+
+
+############################################################################
+# UK Specific Holidays
+############################################################################
+
+# Remarkably, in 2022 SIFMA recommended NO new year's day observance in the US (Saturday)
+#             but in the UK it was observed on Monday requiring a different rule
+UKNewYearsDay = Holiday(
+    'New Years Day',
+    month=1,
+    day=1,
+    observance=next_monday,
+)
+
+UKGoodFriday = Holiday(
+    "Good Friday", 
+    month=1, 
+    day=1, 
+    offset=[Easter(), Day(-2)]
+)
+
+UKEasterMonday = Holiday(
+    "Easter Monday", 
+    month=1, 
+    day=1, 
+    offset=[Easter(), Day(+1)]
+)
+
+# Observed first Monday in May
+UKMayDay = Holiday(
+    "May Day",
+    month=5,
+    day=1,
+    offset=DateOffset(weekday=MO(1)),   
+)
+
+# Almost always follows US Memorial Day except for
+UKSpringBankAdHoc = [Timestamp('2022-06-02', tz='UTC'),]
+
+UKPlatinumJubilee2022 = [Timestamp('2022-06-03', tz='UTC'),]
+
+# Observed last Monday in August in England, Wales, and Northern Ireland
+# Observed first Monday in August in Scotland
+# Coded as last Monday
+# https://www.timeanddate.com/holidays/uk/summer-bank-holiday
+UKSummerBank = Holiday(
+    "Summer Bank Holiday",
+    month=8,
+    day=30,
+    offset=DateOffset(weekday=MO(-1)),
+)
+
+
+
+# UK observes Christmas on Tuesday when Boxing Day is on Monday
+# UK observes Christmas on Monday when Christmas is on Saturday
+UKChristmaEve = Holiday(
+    "Christmas",
+    month=12,
+    day=24,
+    days_of_week=(FRIDAY,),
+)
+
+UKChristmas = Holiday(
+    "Christmas",
+    month=12,
+    day=25,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
+)
+
+# If christmas day is Saturday Monday 27th is a holiday
+# If christmas day is sunday the Tuesday 27th is a holiday
+UKWeekendChristmas = Holiday(
+    "Weekend Christmas",
+    month=12,
+    day=27,
+    days_of_week=(MONDAY, TUESDAY),
+)
+
+# Boxing day
+UKBoxingDay = Holiday(
+    "Boxing Day",
+    month=12,
+    day=26,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
+)
+
+# If boxing day is saturday then Monday 28th is a holiday
+# If boxing day is sunday then Tuesday 28th is a holiday
+UKWeekendBoxingDay = Holiday(
+    "Weekend Boxing Day",
+    month=12,
+    day=28,
+    days_of_week=(MONDAY, TUESDAY),
+)

--- a/tests/test_sifma_calendars.py
+++ b/tests/test_sifma_calendars.py
@@ -1,0 +1,398 @@
+
+import pytz
+import pandas as pd
+from pandas.testing import assert_index_equal
+
+
+from pandas_market_calendars.exchange_calendar_sifma import (SIFMAUSExchangeCalendar,
+                                                             SIFMAUKExchangeCalendar,
+                                                             SIFMAJPExchangeCalendar)
+
+
+#########################################################################
+# HELPER FUNCTIONS
+#########################################################################
+def _test_holidays(cal, holidays, start, end):
+    df = pd.DataFrame(cal.holidays().holidays, columns=['holidays'])
+    mask = (df['holidays'] >= start) & (df['holidays'] <= end)
+    df = df[mask]
+    assert len(holidays) == len(df)   
+    df = df.set_index(['holidays'])
+    df.index = df.index.tz_localize('UTC')
+    assert_index_equal(pd.DatetimeIndex(holidays), df.index, check_names=False)
+    valid_days = cal.valid_days(start, end)
+    for h in holidays:
+        assert h not in valid_days
+
+def _test_no_special_opens(cal, start, end):
+    assert len(cal.late_opens(cal.schedule(start, end))) == 0
+    
+def _test_no_special_closes(cal, start, end):
+    assert len(cal.early_closes(cal.schedule(start, end))) == 0
+
+def _test_no_special_opens_closes(cal, start, end):
+    _test_no_special_opens(cal, start, end)
+    _test_no_special_closes(cal, start, end) 
+
+def _test_verify_late_open_time(schedule, timestamp):
+    date = pd.Timestamp(pd.Timestamp(timestamp).tz_convert('UTC').date())
+    if date in schedule.index:
+        return schedule.at[date, 'market_open'] == timestamp
+    else:
+        return False
+    
+def _test_has_late_opens(cal, late_opens, start, end):
+    schedule = cal.schedule(start, end)
+    expected = cal.late_opens(schedule)
+    assert len(expected) == len(late_opens)
+    for ts in late_opens:
+        assert _test_verify_late_open_time(schedule, ts) == True
+    
+def _test_verify_early_close_time(schedule, timestamp):
+    date = pd.Timestamp(pd.Timestamp(timestamp).tz_convert('UTC').date())
+    if date in schedule.index:
+        return schedule.at[date, 'market_close'] == timestamp
+    else:
+        return False
+    
+def _test_has_early_closes(cal, early_closes, start, end):
+    schedule = cal.schedule(start, end)
+    expected = cal.early_closes(schedule)
+    assert len(expected) == len(early_closes)
+    for ts in early_closes:
+       assert _test_verify_early_close_time(schedule, ts) == True
+
+#########################################################################
+# US TESTS
+#########################################################################
+sifma_us = SIFMAUSExchangeCalendar()
+
+def test_us_time_zone():
+    assert sifma_us.tz == pytz.timezone('America/New_York')
+    assert sifma_us.name == 'SIFMA_US'
+
+def test_us_open_time_tz():
+    assert sifma_us.open_time.tzinfo == sifma_us.tz
+
+def test_us_close_time_tz():
+    assert sifma_us.close_time.tzinfo == sifma_us.tz
+    
+def test_us_weekmask():
+    assert sifma_us.weekmask == "Mon Tue Wed Thu Fri"           
+                           
+
+def test_us_2023():
+    start = '2023-01-01'
+    end   = '2023-12-31'    
+    holidays = [
+        pd.Timestamp('2023-01-02', tz='UTC'), # New Year's Day
+        pd.Timestamp('2023-01-16', tz='UTC'), # MLK
+        pd.Timestamp('2023-02-20', tz='UTC'), # Presidents Day
+        pd.Timestamp('2023-05-29', tz='UTC'), # Memorial Day
+        pd.Timestamp('2023-06-19', tz='UTC'), # Juneteenth
+        pd.Timestamp('2023-07-04', tz='UTC'), # Independence Day
+        pd.Timestamp('2023-09-04', tz='UTC'), # Labor Day
+        pd.Timestamp('2023-10-09', tz='UTC'), # Columbus Day
+        pd.Timestamp('2023-11-23', tz='UTC'), # Thanksgiving
+        pd.Timestamp('2023-12-25', tz='UTC')  # Christmas
+    ]
+    _test_holidays(sifma_us, holidays, start, end)
+    _test_no_special_opens(sifma_us, start, end)
+
+    # early closes we expect:
+    early_closes = [     
+        pd.Timestamp('2023-04-07 2:00PM', tz='America/New_York'), # Good Friday
+        pd.Timestamp('2023-05-26 2:00PM', tz='America/New_York'), # Day before Memorial Day
+        pd.Timestamp('2023-07-03 2:00PM', tz='America/New_York'), # Day before Independence Day
+        pd.Timestamp('2023-11-24 2:00PM', tz='America/New_York'), # Day after Thanksgiving
+        pd.Timestamp('2023-12-22 2:00PM', tz='America/New_York'), # Day before Christmas
+        pd.Timestamp('2023-12-29 2:00PM', tz='America/New_York'), # New Year's Eve
+    ]
+    _test_has_early_closes(sifma_us, early_closes, start, end)
+
+
+def test_us_2022():
+    start = '2022-01-01'
+    end   = '2022-12-31'    
+    holidays = [
+        pd.Timestamp('2022-01-17', tz='UTC'), # MLK
+        pd.Timestamp('2022-02-21', tz='UTC'), # Presidents Day
+        pd.Timestamp('2022-04-15', tz='UTC'), # Good Friday
+        pd.Timestamp('2022-05-30', tz='UTC'), # Memorial Day
+        pd.Timestamp('2022-06-20', tz='UTC'), # Juneteenth
+        pd.Timestamp('2022-07-04', tz='UTC'), # Independence Day
+        pd.Timestamp('2022-09-05', tz='UTC'), # Labor Day
+        pd.Timestamp('2022-10-10', tz='UTC'), # Columbus Day
+        pd.Timestamp('2022-11-11', tz='UTC'), # Veterans Day
+        pd.Timestamp('2022-11-24', tz='UTC'), # Thanksgiving
+        pd.Timestamp('2022-12-26', tz='UTC')  # Christmas
+    ]
+    _test_holidays(sifma_us, holidays, start, end)
+    _test_no_special_opens(sifma_us,start, end)
+
+    # early closes we expect:
+    early_closes = [     
+        pd.Timestamp('2022-04-14 2:00PM', tz='America/New_York'), # Day before Good Friday
+        pd.Timestamp('2022-05-27 2:00PM', tz='America/New_York'), # Day before Memorial Day
+        pd.Timestamp('2022-07-01 2:00PM', tz='America/New_York'), # Day before Independence Day
+        pd.Timestamp('2022-11-25 2:00PM', tz='America/New_York'), # Day after Thanksgiving
+        pd.Timestamp('2022-12-23 2:00PM', tz='America/New_York'), # Day before Christmas
+        pd.Timestamp('2022-12-30 2:00PM', tz='America/New_York') # New Year's Eve
+    ]
+    _test_has_early_closes(sifma_us, early_closes, start, end)
+
+def test_us_2021():
+    start = '2021-01-01'
+    end   = '2021-12-31'    
+    holidays = [
+        pd.Timestamp('2021-01-01', tz='UTC'), # New Year's Day
+        pd.Timestamp('2021-01-18', tz='UTC'), # MLK
+        pd.Timestamp('2021-02-15', tz='UTC'), # Presidents Day
+        pd.Timestamp('2021-05-31', tz='UTC'), # Memorial Day
+        pd.Timestamp('2021-07-05', tz='UTC'), # Independence Day
+        pd.Timestamp('2021-09-06', tz='UTC'), # Labor Day
+        pd.Timestamp('2021-10-11', tz='UTC'), # Columbus Day
+        pd.Timestamp('2021-11-11', tz='UTC'), # Veterans Day
+        pd.Timestamp('2021-11-25', tz='UTC'), # Thanksgiving
+        pd.Timestamp('2021-12-24', tz='UTC')  # Christmas
+    ]
+    _test_holidays(sifma_us, holidays, start, end)
+    _test_no_special_opens(sifma_us, start, end)
+
+    # early closes we expect:
+    early_closes = [     
+        pd.Timestamp('2021-04-02 2:00PM', tz='America/New_York'), # Day before Good Friday
+        pd.Timestamp('2021-05-28 2:00PM', tz='America/New_York'), # Day before Memorial Day
+        pd.Timestamp('2021-07-02 2:00PM', tz='America/New_York'), # Day before Independence Day
+        pd.Timestamp('2021-11-26 2:00PM', tz='America/New_York'), # Day after Thanksgiving
+        pd.Timestamp('2021-12-23 2:00PM', tz='America/New_York'), # Day before Christmas
+        pd.Timestamp('2021-12-31 2:00PM', tz='America/New_York') # New Year's Eve
+    ]
+    _test_has_early_closes(sifma_us, early_closes, start, end)
+
+def test_us_2020():
+    start = '2020-01-01'
+    end   = '2020-12-31'    
+    holidays = [
+        pd.Timestamp('2020-01-01', tz='UTC'), # New Year's Day
+        pd.Timestamp('2020-01-20', tz='UTC'), # MLK
+        pd.Timestamp('2020-02-17', tz='UTC'), # Presidents Day
+        pd.Timestamp('2020-04-10', tz='UTC'), # Good Friday
+        pd.Timestamp('2020-05-25', tz='UTC'), # Memorial Day
+        pd.Timestamp('2020-07-03', tz='UTC'), # Independence Day
+        pd.Timestamp('2020-09-07', tz='UTC'), # Labor Day
+        pd.Timestamp('2020-10-12', tz='UTC'), # Columbus Day
+        pd.Timestamp('2020-11-11', tz='UTC'), # Veterans Day
+        pd.Timestamp('2020-11-26', tz='UTC'), # Thanksgiving
+        pd.Timestamp('2020-12-25', tz='UTC')  # Christmas
+    ]
+    _test_holidays(sifma_us, holidays, start, end)
+    _test_no_special_opens(sifma_us, start, end)
+
+    # early closes we expect:
+    early_closes = [     
+        pd.Timestamp('2020-04-09 2:00PM', tz='America/New_York'), # Day before Good Friday
+        pd.Timestamp('2020-05-22 2:00PM', tz='America/New_York'), # Day before Memorial Day
+        pd.Timestamp('2020-07-02 2:00PM', tz='America/New_York'), # Day before Independence Day
+        pd.Timestamp('2020-11-27 2:00PM', tz='America/New_York'), # Day after Thanksgiving
+        pd.Timestamp('2020-12-24 2:00PM', tz='America/New_York'), # Day before Christmas
+        pd.Timestamp('2020-12-31 2:00PM', tz='America/New_York')  # New Year's Eve
+    ]
+    _test_has_early_closes(sifma_us, early_closes, start, end)
+
+def test_us_2019():
+    start = '2019-01-01'
+    end   = '2019-12-31'    
+    holidays = [
+        pd.Timestamp('2019-01-01', tz='UTC'),
+        pd.Timestamp('2019-01-21', tz='UTC'),
+        pd.Timestamp('2019-02-18', tz='UTC'),
+        pd.Timestamp('2019-04-19', tz='UTC'),
+        pd.Timestamp('2019-05-27', tz='UTC'),
+        pd.Timestamp('2019-07-04', tz='UTC'),
+        pd.Timestamp('2019-09-02', tz='UTC'),
+        pd.Timestamp('2019-10-14', tz='UTC'),
+        pd.Timestamp('2019-11-11', tz='UTC'),
+        pd.Timestamp('2019-11-28', tz='UTC'),
+        pd.Timestamp('2019-12-25', tz='UTC'),
+    ]
+    _test_holidays(sifma_us, holidays, start, end)
+    _test_no_special_opens(sifma_us, start, end)
+
+    # early closes we expect:
+    early_closes = [     
+        pd.Timestamp('2019-04-18 2:00PM', tz='America/New_York'), # Day before Good Friday
+        pd.Timestamp('2019-05-24 2:00PM', tz='America/New_York'), # Day before Memorial Day
+        pd.Timestamp('2019-07-03 2:00PM', tz='America/New_York'), # Day before Independence Day
+        pd.Timestamp('2019-11-29 2:00PM', tz='America/New_York'), # Day after Thanksgiving
+        pd.Timestamp('2019-12-24 2:00PM', tz='America/New_York'), # Day before Christmas
+        pd.Timestamp('2019-12-31 2:00PM', tz='America/New_York')  # New Year's Eve
+    ]
+    _test_has_early_closes(sifma_us, early_closes, start, end)
+
+
+#########################################################################
+# UK TESTS
+#########################################################################
+sifma_uk = SIFMAUKExchangeCalendar()
+
+def test_uk_time_zone():
+    assert sifma_uk.tz == pytz.timezone('Europe/London')
+    assert sifma_uk.name == 'SIFMA_UK'
+
+def test_uk_open_time_tz():
+    assert sifma_uk.open_time.tzinfo == sifma_uk.tz
+
+def test_uk_close_time_tz():
+    assert sifma_uk.close_time.tzinfo == sifma_uk.tz
+    
+def test_uk_weekmask():
+    assert sifma_uk.weekmask == "Mon Tue Wed Thu Fri"           
+
+def test_uk_2023():
+    start = '2023-01-01'
+    end   = '2023-12-31'    
+    holidays = [
+        pd.Timestamp('2023-01-02', tz='UTC'), # New Year's Day
+        pd.Timestamp('2023-01-16', tz='UTC'), # MLK
+        pd.Timestamp('2023-02-20', tz='UTC'), # US Presidents Day
+        pd.Timestamp('2023-04-07', tz='UTC'), # Good Friday
+        pd.Timestamp('2023-04-10', tz='UTC'), # Easter Monday
+        pd.Timestamp('2023-05-01', tz='UTC'), # May Day
+        pd.Timestamp('2023-05-29', tz='UTC'), # Memorial Day + Spring Bank Holiday
+        pd.Timestamp('2023-06-19', tz='UTC'), # Juneteenth
+        pd.Timestamp('2023-07-04', tz='UTC'), # US Independence Day
+        pd.Timestamp('2023-08-28', tz='UTC'), # UK Summer Bank Holiday
+        pd.Timestamp('2023-09-04', tz='UTC'), # US Labor Day
+        pd.Timestamp('2023-10-09', tz='UTC'), # US Columbus Day
+        pd.Timestamp('2023-11-23', tz='UTC'), # US Thanksgiving
+        pd.Timestamp('2023-12-25', tz='UTC'), # Christmas
+        pd.Timestamp('2023-12-26', tz='UTC')  # Boxing Day
+    ]
+    _test_holidays(sifma_uk, holidays, start, end)
+    _test_no_special_opens_closes(sifma_uk, start, end)
+
+def test_uk_2022():
+    start = '2022-01-01'
+    end   = '2022-12-31'    
+    holidays = [
+        pd.Timestamp('2022-01-03', tz='UTC'), # New Year's Day
+        pd.Timestamp('2022-01-17', tz='UTC'), # MLK
+        pd.Timestamp('2022-02-21', tz='UTC'), # US Presidents Day
+        pd.Timestamp('2022-04-15', tz='UTC'), # Good Friday
+        pd.Timestamp('2022-04-18', tz='UTC'), # Easter Monday
+        pd.Timestamp('2022-05-02', tz='UTC'), # May Day
+        pd.Timestamp('2022-05-30', tz='UTC'), # Memorial Day
+        pd.Timestamp('2022-06-02', tz='UTC'), # Spring Bank Holiday
+        pd.Timestamp('2022-06-03', tz='UTC'), # Platinum Jubilee
+        pd.Timestamp('2022-06-20', tz='UTC'), # Juneteenth
+        pd.Timestamp('2022-07-04', tz='UTC'), # US Independence Day
+        pd.Timestamp('2022-08-29', tz='UTC'), # UK Summer Bank Holiday
+        pd.Timestamp('2022-09-05', tz='UTC'), # US Labor Day
+        pd.Timestamp('2022-10-10', tz='UTC'), # US Columbus Day
+        pd.Timestamp('2022-11-11', tz='UTC'), # US Vetrans Day
+        pd.Timestamp('2022-11-24', tz='UTC'), # US Thanksgiving
+        pd.Timestamp('2022-12-26', tz='UTC'), # Boxing Day
+        pd.Timestamp('2022-12-27', tz='UTC'), # Christmas
+    ]
+    _test_holidays(sifma_uk, holidays, start, end)
+    _test_no_special_opens_closes(sifma_uk, start, end)
+
+def test_uk_2021():
+    start = '2021-01-01'
+    end   = '2021-12-31'    
+    holidays = [
+        pd.Timestamp('2021-01-01', tz='UTC'), # New Year's Day
+        pd.Timestamp('2021-01-18', tz='UTC'), # MLK
+        pd.Timestamp('2021-02-15', tz='UTC'), # US Presidents Day
+        pd.Timestamp('2021-04-02', tz='UTC'), # Good Friday
+        pd.Timestamp('2021-04-05', tz='UTC'), # Easter Monday
+        pd.Timestamp('2021-05-03', tz='UTC'), # May Day
+        pd.Timestamp('2021-05-31', tz='UTC'), # Memorial Day + Spring Bank Holiday
+        pd.Timestamp('2021-07-05', tz='UTC'), # US Independence Day
+        pd.Timestamp('2021-08-30', tz='UTC'), # UK Summer Bank Holiday
+        pd.Timestamp('2021-09-06', tz='UTC'), # US Labor Day
+        pd.Timestamp('2021-10-11', tz='UTC'), # US Columbus Day
+        pd.Timestamp('2021-11-11', tz='UTC'), # US Vetrans Day
+        pd.Timestamp('2021-11-25', tz='UTC'), # US Thanksgiving
+        pd.Timestamp('2021-12-24', tz='UTC'), # Friday Christmas Eve
+        pd.Timestamp('2021-12-27', tz='UTC'), # Christmas
+        pd.Timestamp('2021-12-28', tz='UTC'), # Boxing Day
+    ]
+    _test_holidays(sifma_uk, holidays, start, end)
+    _test_no_special_opens_closes(sifma_uk, start, end)
+
+
+#########################################################################
+# Japan TESTS
+#########################################################################
+sifma_jp = SIFMAJPExchangeCalendar()
+
+def test_jp_time_zone():
+    assert sifma_jp.tz == pytz.timezone('Asia/Tokyo')
+    assert sifma_jp.name == 'SIFMA_JP'
+
+def test_jp_open_time_tz():
+    assert sifma_jp.open_time.tzinfo == sifma_jp.tz
+
+def test_jp_close_time_tz():
+    assert sifma_jp.close_time.tzinfo == sifma_jp.tz
+    
+def test_jp_weekmask():
+    assert sifma_jp.weekmask == "Mon Tue Wed Thu Fri"           
+
+def test_jp_2022():
+    start = '2022-01-01'
+    end   = '2022-12-31'    
+    holidays = [
+        pd.Timestamp('2022-01-03', tz='UTC'), # New Year's Day
+        pd.Timestamp('2022-01-10', tz='UTC'), # Japan Coming of Age Day
+        pd.Timestamp('2022-01-17', tz='UTC'), # US MLK
+        pd.Timestamp('2022-02-11', tz='UTC'), # Japan National Foundation Day
+        pd.Timestamp('2022-02-21', tz='UTC'), # US Presidents Day
+        pd.Timestamp('2022-02-23', tz='UTC'), # Japan Emporer's Birthday
+        pd.Timestamp('2022-03-21', tz='UTC'), # Japan Vernal Equinox
+        pd.Timestamp('2022-04-15', tz='UTC'), # UK Good Friday
+        pd.Timestamp('2022-04-18', tz='UTC'), # UK Easter Monday
+        pd.Timestamp('2022-04-29', tz='UTC'), # Japan Showa Day
+        pd.Timestamp('2022-05-03', tz='UTC'), # Japan Constitution Day
+        pd.Timestamp('2022-05-04', tz='UTC'), # Japan Greenery Day
+        pd.Timestamp('2022-05-05', tz='UTC'), # Japan Children's Day
+        pd.Timestamp('2022-05-30', tz='UTC'), # US Memorial Day
+        pd.Timestamp('2022-06-02', tz='UTC'), # UK Spring Bank Holiday
+        pd.Timestamp('2022-06-03', tz='UTC'), # UK Platinum Jubilee
+        pd.Timestamp('2022-06-20', tz='UTC'), # Juneteenth
+        pd.Timestamp('2022-07-04', tz='UTC'), # US Independence Day
+        pd.Timestamp('2022-07-18', tz='UTC'), # Japan Marine Day
+        pd.Timestamp('2022-08-11', tz='UTC'), # Japan Mountain Day
+        pd.Timestamp('2022-08-29', tz='UTC'), # UK Summer Bank Holiday
+        pd.Timestamp('2022-09-05', tz='UTC'), # US Labor Day
+        pd.Timestamp('2022-09-19', tz='UTC'), # Japan Respect-for-the-Aged Day
+        pd.Timestamp('2022-09-23', tz='UTC'), # Japan Autumnal Equinox
+        pd.Timestamp('2022-10-10', tz='UTC'), # Japan Health and Sports Day
+        pd.Timestamp('2022-11-03', tz='UTC'), # Japan Culture Day
+        pd.Timestamp('2022-11-11', tz='UTC'), # US Vetrans Day
+        pd.Timestamp('2022-11-23', tz='UTC'), # Japan Labour Thanksgiving Day
+        pd.Timestamp('2022-11-24', tz='UTC'), # US Thanksgiving
+        pd.Timestamp('2022-12-26', tz='UTC'), # Boxing Day
+    ]
+    _test_holidays(sifma_jp, holidays, start, end)
+    _test_no_special_opens(sifma_jp, start, end)
+
+    early_closes = [     
+        pd.Timestamp('2022-05-02 3:00PM', tz='Asia/Tokyo'), # UK May Day 
+        pd.Timestamp('2022-12-27 3:00PM', tz='Asia/Tokyo'), # UK Christmas Day
+      ]
+    _test_has_early_closes(sifma_jp, early_closes, start, end)
+
+ 
+
+if __name__ == '__main__':
+
+    for ref, obj in locals().copy().items():
+
+        if ref.startswith("test_"):
+            print("running ", ref)
+            obj()
+
+           


### PR DESCRIPTION
Support for SIFMA Calendars.

US: Tested  2019 thru 2023
UK: Tested  2020 thru 2023 
JP: Tested  2022

Note: AbstractHolidayCalendar.start_date commented out on line 76 of exchange_calendar_sifma.py as it causes other tests to fail when run together. Uncommented, all tests run individually. I'm not sure how to re-initialize it. This is a test-only issue but the calendar really shouldn't be valid prior to 1998.