### PR TITLE
Adjust BMF calendar for regional holidays and covid calendar changes

### DIFF
--- a/pandas_market_calendars/exchange_calendar_bmf.py
+++ b/pandas_market_calendars/exchange_calendar_bmf.py
@@ -31,6 +31,7 @@ AniversarioSaoPaulo = Holiday(
     'Aniversario de Sao Paulo',
     month=1,
     day=25,
+    end_date='2021-12-31'
 )
 # Carnival Monday
 CarnavalSegunda = Holiday(
@@ -79,7 +80,8 @@ Constitucionalista = Holiday(
     'Constitucionalista',
     month=7,
     day=9,
-    start_date='1997-01-01'
+    start_date='1997-01-01',
+    end_date='2021-12-31'
 )
 # Independence Day
 Independencia = Holiday(
@@ -110,7 +112,8 @@ ConscienciaNegra = Holiday(
     'Dia da Consciencia Negra',
     month=11,
     day=20,
-    start_date='2004-01-01'
+    start_date='2004-01-01',
+    end_date='2021-12-31'
 )
 # Christmas Eve
 VesperaNatal = Holiday(
@@ -148,19 +151,19 @@ class BMFExchangeCalendar(MarketCalendar):
 
     Regularly-Observed Holidays:
     - Universal Confraternization (New year's day, Jan 1)
-    - Sao Paulo City Anniversary (Jan 25)
+    - Sao Paulo City Anniversary (Jan 25 until 2021)
     - Carnaval Monday (48 days before Easter)
     - Carnaval Tuesday (47 days before Easter)
     - Passion of the Christ (Good Friday, 2 days before Easter)
     - Corpus Christi (60 days after Easter)
     - Tiradentes (April 21)
     - Labor day (May 1)
-    - Constitutionalist Revolution (July 9 after 1997)
+    - Constitutionalist Revolution (July 9 after 1997 until 2021)
     - Independence Day (September 7)
     - Our Lady of Aparecida Feast (October 12)
     - All Souls' Day (November 2)
     - Proclamation of the Republic (November 15)
-    - Day of Black Awareness (November 20 after 2004)
+    - Day of Black Awareness (November 20 after 2004 until 2021)
     - Christmas (December 24 and 25)
     - Day before New Year's Eve (December 30 if NYE falls on a Saturday)
     - New Year's Eve (December 31)

--- a/pandas_market_calendars/exchange_calendar_bmf.py
+++ b/pandas_market_calendars/exchange_calendar_bmf.py
@@ -168,7 +168,7 @@ class BMFExchangeCalendar(MarketCalendar):
     - Day before New Year's Eve (December 30 if NYE falls on a Saturday)
     - New Year's Eve (December 31)
     """
-    aliases = ['BMF']
+    aliases = ['BMF', 'B3']
     regular_market_times = {
         "market_open": ((None, time(10,1)),),
         "market_close": ((None, time(16)),)

--- a/pandas_market_calendars/exchange_calendar_bmf.py
+++ b/pandas_market_calendars/exchange_calendar_bmf.py
@@ -15,6 +15,7 @@
 
 from datetime import time
 
+from pandas import Timestamp
 from pandas.tseries.holiday import AbstractHolidayCalendar, Day, Easter, GoodFriday, Holiday
 from pytz import timezone
 
@@ -81,7 +82,7 @@ Constitucionalista = Holiday(
     month=7,
     day=9,
     start_date='1997-01-01',
-    end_date='2021-12-31'
+    end_date='2019-12-31'
 )
 # Independence Day
 Independencia = Holiday(
@@ -113,7 +114,7 @@ ConscienciaNegra = Holiday(
     month=11,
     day=20,
     start_date='2004-01-01',
-    end_date='2021-12-31'
+    end_date='2019-12-31'
 )
 # Christmas Eve
 VesperaNatal = Holiday(
@@ -141,6 +142,13 @@ AnoNovoSabado = Holiday(
     days_of_week=(FRIDAY,),
 )
 
+##########################
+# Non-recurring holidays
+##########################
+
+Constitucionalista2021 = Timestamp('2021-07-09', tz='UTC')
+ConscienciaNegra2021 = Timestamp('2021-11-20', tz='UTC')
+
 
 class BMFExchangeCalendar(MarketCalendar):
     """
@@ -158,12 +166,12 @@ class BMFExchangeCalendar(MarketCalendar):
     - Corpus Christi (60 days after Easter)
     - Tiradentes (April 21)
     - Labor day (May 1)
-    - Constitutionalist Revolution (July 9 after 1997 until 2021)
+    - Constitutionalist Revolution (July 9 after 1997 until 2021, skipping 2020)
     - Independence Day (September 7)
     - Our Lady of Aparecida Feast (October 12)
     - All Souls' Day (November 2)
     - Proclamation of the Republic (November 15)
-    - Day of Black Awareness (November 20 after 2004 until 2021)
+    - Day of Black Awareness (November 20 after 2004 until 2021, skipping 2020)
     - Christmas (December 24 and 25)
     - Day before New Year's Eve (December 30 if NYE falls on a Saturday)
     - New Year's Eve (December 31)
@@ -204,6 +212,13 @@ class BMFExchangeCalendar(MarketCalendar):
             AnoNovo,
             AnoNovoSabado,
         ])
+
+    @property
+    def adhoc_holidays(self):
+        return [
+            Constitucionalista2021,
+            ConscienciaNegra2021
+        ]
 
     @property
     def special_opens(self):

--- a/tests/test_bmf_calendar.py
+++ b/tests/test_bmf_calendar.py
@@ -1,0 +1,31 @@
+import datetime
+import pytest
+import pandas as pd
+import pytz
+
+from pandas_market_calendars.exchange_calendar_bmf import BMFExchangeCalendar
+
+def test_time_zone():
+    assert BMFExchangeCalendar().tz == pytz.timezone("America/Sao_Paulo")
+
+
+def test_2020_holidays_skip():
+    # 2020-07-09 - skipped due to covid
+    # 2020-11-20 - skipped due to covid
+    holidays = BMFExchangeCalendar().holidays().holidays
+    for date in ["2019-07-09", "2019-11-20", "2021-07-09", "2021-11-20"]:
+        assert pd.Timestamp(date, tz="UTC").to_datetime64() in holidays
+    for date in ["2020-07-09", "2020-11-20"]:
+        assert pd.Timestamp(date, tz="UTC").to_datetime64() not in holidays
+
+def test_post_2022_regulation_change():
+    # Regional holidays no longer observed: January 25th, July 9th, November 20th
+    holidays = BMFExchangeCalendar().holidays().holidays
+
+    for year in [2017, 2018, 2019, 2021]: # skip 2020 due to test above
+        for month, day in [(1, 25), (7, 9), (11, 20)]:
+            assert pd.Timestamp(datetime.date(year, month, day), tz="UTC").to_datetime64() in holidays
+
+    for year in range(2022, 2040):
+        for month, day in [(1, 25), (7, 9), (11, 20)]:
+            assert pd.Timestamp(datetime.date(year, month, day), tz="UTC").to_datetime64() not in holidays


### PR DESCRIPTION
1. Removed regional holidays from 2022 forward
2. Removed two cancelled holidays due to covid in 2020
3. Added 'B3' as alias
4. added tests for the above behaviors

Detailed explanation can be found in issue #188.

Note: Since the two cancelled holidays in 2020 were the regional ones removed in 2022, and I found no way to "override" a holiday and force a open market day, I implemented these as such:
- Regular holiday until 2019
- Adhoc  holiday in 2021

This might seem a duplicate from PR #165, but their implementation removed those holidays from the entire history, not from 2022 forward. Their implementation also did not cover the 2020 skips.