### PR TITLE
Adjustments for exchange_calendars v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.8"
   - "3.9"
-  - "3.10"
 
 install:
   - "pip install pandas"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - "3.7"
   - "3.8"
   - "3.9"
+  - "3.10"
 
 install:
   - "pip install pandas"

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ from os import path
 from setuptools import find_packages, setup
 
 # version
-VERSION = '3.4'
+VERSION = '3.5'
 
 # requirements
-REQUIRED_PYTHON = '>=3.7.0'
+REQUIRED_PYTHON = '>=3.8.0'
 REQUIRED_PACKAGES = ['pandas>=1.1', 'pytz', 'python-dateutil', 'exchange_calendars>=3.3']
 
 # Package meta-data
@@ -62,9 +62,9 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         # Specify the Python versions you support here.
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 
     # What does your project relate to?

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -951,7 +951,7 @@ def test_ec_schedule():
     assert not mcaliepa._EC_NOT_INITIALIZED
 
     theirs.index.freq = None
-    theirs.rename(columns={"open": "market_open", "close": "market_close"})
+    theirs = theirs.rename(columns={"open": "market_open", "close": "market_close"})
     assert_frame_equal(ours, theirs)
 
 

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -946,11 +946,12 @@ def test_ec_schedule():
     assert mcaliepa._EC_NOT_INITIALIZED
     ours = mcaliepa.schedule(start, end)
     assert mcaliepa._EC_NOT_INITIALIZED
-    theirs = mcaliepa.ec.schedule[["market_open", "market_close"]]
+
+    theirs = mcaliepa.ec.schedule[["open", "close"]]
     assert not mcaliepa._EC_NOT_INITIALIZED
 
-    theirs = theirs.tz_localize(None) # our indexes are tz-naive, theirs are in UTC
-    for col in theirs: theirs[col] = theirs[col].dt.tz_localize("UTC") # our columns are in UTC but theirs are naive
+    theirs.index.freq = None
+    theirs.rename(columns={"open": "market_open", "close": "market_close"})
     assert_frame_equal(ours, theirs)
 
 


### PR DESCRIPTION
* Sets minimum python to 3.8
* Adjusts test to work with the new schedule layout
* Increments pandas_market_calendars to version 3.5 in setup.py