### PR TITLE
Extraordinary market times

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,11 @@ markets that have a lunch break, or futures markets that are open 24 hours with 
 As of v2.0 this package provides a mirror of all the calendars from the `exchange_calendars <https://github.com/gerrymanoim/exchange_calendars>`_
 package, which itself is the now maintained fork of the original trading_calendars package. This adds over 50 calendars.
 
+As of v3.0, the function date_range() is more complete and consistent, for more discussion on the topic refer to PR #142 and Issue #138.
+
+As of v4.0, this package provides the framework to add interruptions to calendars. These can also be added to a schedule and viewed using
+the new interruptions_df property. A full list of changes can be found in PR #210.
+
 Source location
 ~~~~~~~~~~~~~~~
 Hosted on GitHub: https://github.com/rsheftel/pandas_market_calendars

--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -3,6 +3,14 @@
 
 Updates
 -------
+4.0 (08/02/22)
+~~~~~~~~~~~~~~
+- Added interruptions support
+- Updated MarketCalendar.open_at_time to respect interruptions
+- Special times can be set with offsets
+- MarketCalendar.days_at_time returns a pandas.Series
+- calendar_utils.date_range supports schedules of any timezone
+
 3.5 (06/25/22)
 ~~~~~~~~~~~~~~
 - Updated BMF

--- a/docs/new_market.rst
+++ b/docs/new_market.rst
@@ -18,10 +18,10 @@ To create a new exchange (or OTC market):
       #. If there is a break, there must be a "break_start" and a "break_end".
       #. only ONE break is currently supported.
 
-   #. One list/tuple for each market_time, containing at least one list/tuple:
+   #. One tuple for each market_time, containing at least one tuple:
 
-      #. Each nested iterable needs at least two items: `(first_date_used, time[, offset])`.
-      #. The first iterable's date should be None, marking the start. In every iterable thereafter this is the date when `time` was first used.
+      #. Each nested tuple needs at least two items: `(first_date_used, time[, offset])`.
+      #. The first tuple's date should be None, marking the start. In every tuple thereafter this is the date when `time` was first used.
       #. Optionally (assumed to be zero, when not present), a positive or negative integer, representing an offset in number of days.
       #. Dates need to be in ascending order, None coming first.
 
@@ -55,6 +55,9 @@ To create a new exchange (or OTC market):
       #. special_{market_time}
            same format as special_opens, which is the same as special_market_open
 
+   #. Add interruptions:
+
+      #. interruptions - returns a list of tuples. The tuple is (date, start_time, end_time[, start_time2, end_time2, ...])
 
 
 #. Import your new calendar class in `calendar_registry.py`:

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -53,7 +53,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -85,7 +87,7 @@
     {
      "data": {
       "text/plain": [
-       "(numpy.datetime64('2200-05-26'),\n",
+       "(numpy.datetime64('2200-06-19'),\n",
        " numpy.datetime64('2200-07-04'),\n",
        " numpy.datetime64('2200-09-01'),\n",
        " numpy.datetime64('2200-11-27'),\n",
@@ -471,7 +473,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -566,7 +570,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -620,7 +626,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [
     {
      "data": {
@@ -683,7 +691,7 @@
    "metadata": {},
    "source": [
     "### Open at time\n",
-    "Test to see if a given timestamp is during market open hours"
+    "Test to see if a given timestamp is during market open hours. (You can find more on this under the 'Advanced open_at_time' header)"
    ]
   },
   {
@@ -784,7 +792,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Customizations"
+    "# Customizations"
    ]
   },
   {
@@ -871,10 +879,10 @@
     "    * only ONE break is currently supported.\n",
     "\n",
     "\n",
-    "* One list/tuple for each market_time, containing at least one list/tuple:\n",
+    "* One tuple for each market_time, containing at least one tuple:\n",
     "\n",
-    "    * Each nested iterable needs at least two items: `(first_date_used, time[, offset])`.\n",
-    "    * The first iterable's date should be None, marking the start. In every iterable thereafter this is the date when `time` was first used.\n",
+    "    * Each nested tuple needs at least two items: `(first_date_used, time[, offset])`.\n",
+    "    * The first tuple's date should be None, marking the start. In every tuple thereafter this is the date when `time` was first used.\n",
     "    * Optionally (assumed to be zero, when not present), a positive or negative integer, representing an offset in number of days.\n",
     "    * Dates need to be in ascending order, None coming first.\n",
     "    \n",
@@ -950,7 +958,9 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1026,7 +1036,7 @@
     "### CAVEATS:\n",
     "\n",
     "#### FIRST\n",
-    "*Internally, a an order of market_times is detected based on their current time*.\\\n",
+    "*Internally, an order of market_times is detected based on their current time*.\\\n",
     "Because of the offsets in \"with_offset\" and \"changes_and_offset\", the columns in a schedule are in the following order:"
    ]
   },
@@ -1313,7 +1323,9 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [
     {
      "data": {
@@ -1381,9 +1393,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Inheriting from a MarketCalendar\n",
+    "## Inheriting from a MarketCalendar\n",
     "\n",
-    "You get even more control over a calendar (or help this package by contributing a calendar) by inheriting from a MarketCalendar class, which is as simple as this:"
+    "You get even more control over a calendar (or help this package by contributing a calendar) by inheriting from a MarketCalendar class. The following three sections cover:\n",
+    "    \n",
+    "    * Setting special times for market_times\n",
+    "    * Setting interruptions\n",
+    "    * How to make sure open_at_time works"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Special Times\n",
+    "\n",
+    "Any market_time in regular_market_times can have special times, which are looked for in two properties:\n",
+    "\n",
+    "    special_{market_time}_adhoc\n",
+    "        same format as special_opens_adhoc, which is the same as special_market_open_adhoc\n",
+    "    special_{market_time}\n",
+    "        same format as special_opens, which is the same as special_market_open\n",
+    "\n"
    ]
   },
   {
@@ -1392,28 +1423,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# CFEExchangeCalendar only has the regular trading hours for the futures exchange (8:30 - 15:15).\n",
-    "# But you want to use the equity options exchange (8:30 - 15:00), including the order acceptance time at 7:30.\n",
-    "# Maybe you even know some special cases when the order acceptance time was different....\n",
+    "# For example, CFEExchangeCalendar only has the regular trading hours for the futures exchange (8:30 - 15:15).\n",
+    "# If you want to use the equity options exchange (8:30 - 15:00), including the order acceptance time at 7:30, and\n",
+    "# some special cases when the order acceptance time was different, do this:\n",
     "\n",
     "from pandas_market_calendars.exchange_calendar_cboe import CFEExchangeCalendar \n",
     "\n",
-    "class DemoOptionsExchangeCalendar(CFEExchangeCalendar):  # Inherit what doesn't need to change\n",
-    "    name = \"Demo_CBOE_Equity_Options\"\n",
+    "class DemoOptionsCalendar(CFEExchangeCalendar):  # Inherit what doesn't need to change\n",
+    "    name = \"Demo_Options\"\n",
     "    aliases = [name]\n",
     "    regular_market_times = {**CFEExchangeCalendar.regular_market_times, # unpack the parent's regular_market_times\n",
     "                            \"order_acceptance\": ((None, time(7,30)),),  # add your market time of interest\n",
-    "                            \"market_close\": ((None, time(15)),)} # overwrite the market time you want to change\n",
+    "                            \"market_close\": ((None, time(15)),)} # overwrite the market time you want to change  \n",
     "    \n",
-    "    @property  ## See the 'Special times' header below \n",
-    "    def special_order_acceptance_adhoc(self):    # use the special_{market_time}_adhoc functionality to include special cases\n",
+    "    @property\n",
+    "    def special_order_acceptance_adhoc(self):  # include special cases\n",
     "        return [(time(8,30), [\"2000-12-27\", \"2001-12-27\"])]\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1428,7 +1461,7 @@
     }
    ],
    "source": [
-    "options = mcal.get_calendar(\"Demo_CBOE_Equity_Options\")\n",
+    "options = mcal.get_calendar(\"Demo_Options\")\n",
     "\n",
     "print(options.regular_market_times)"
    ]
@@ -1436,7 +1469,9 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -1528,25 +1563,682 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Special times"
+    "### Interruptions\n",
+    "\n",
+    "MarketCalendar subclasses also support interruptions, which can be defined in the `interruptions` property. To view interruptions, you can use the `interruptions_df` property or set `interruptions= True` when calling `schedule`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class InterruptionsDemo(DemoOptionsCalendar):\n",
+    "    @property\n",
+    "    def interruptions(self):\n",
+    "        return [\n",
+    "            (\"2002-02-03\", (time(11), -1), time(11, 2)),\n",
+    "            (\"2010-01-11\", time(11), (time(11, 1), 1)),\n",
+    "            (\"2010-01-13\", time(9, 59), time(10), time(10, 29), time(10, 30)),\n",
+    "            (\"2011-01-10\", time(11), time(11, 1))]\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal = InterruptionsDemo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>interruption_start_1</th>\n",
+       "      <th>interruption_end_1</th>\n",
+       "      <th>interruption_start_2</th>\n",
+       "      <th>interruption_end_2</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2002-02-03</th>\n",
+       "      <td>2002-02-02 17:00:00+00:00</td>\n",
+       "      <td>2002-02-03 17:02:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-11</th>\n",
+       "      <td>2010-01-11 17:00:00+00:00</td>\n",
+       "      <td>2010-01-12 17:01:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-13</th>\n",
+       "      <td>2010-01-13 15:59:00+00:00</td>\n",
+       "      <td>2010-01-13 16:00:00+00:00</td>\n",
+       "      <td>2010-01-13 16:29:00+00:00</td>\n",
+       "      <td>2010-01-13 16:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2011-01-10</th>\n",
+       "      <td>2011-01-10 17:00:00+00:00</td>\n",
+       "      <td>2011-01-10 17:01:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                interruption_start_1        interruption_end_1  \\\n",
+       "2002-02-03 2002-02-02 17:00:00+00:00 2002-02-03 17:02:00+00:00   \n",
+       "2010-01-11 2010-01-11 17:00:00+00:00 2010-01-12 17:01:00+00:00   \n",
+       "2010-01-13 2010-01-13 15:59:00+00:00 2010-01-13 16:00:00+00:00   \n",
+       "2011-01-10 2011-01-10 17:00:00+00:00 2011-01-10 17:01:00+00:00   \n",
+       "\n",
+       "                interruption_start_2        interruption_end_2  \n",
+       "2002-02-03                       NaT                       NaT  \n",
+       "2010-01-11                       NaT                       NaT  \n",
+       "2010-01-13 2010-01-13 16:29:00+00:00 2010-01-13 16:30:00+00:00  \n",
+       "2011-01-10                       NaT                       NaT  "
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cal.interruptions_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>market_close</th>\n",
+       "      <th>interruption_start_1</th>\n",
+       "      <th>interruption_end_1</th>\n",
+       "      <th>interruption_start_2</th>\n",
+       "      <th>interruption_end_2</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2010-01-11</th>\n",
+       "      <td>2010-01-11 14:30:00+00:00</td>\n",
+       "      <td>2010-01-11 21:00:00+00:00</td>\n",
+       "      <td>2010-01-11 17:00:00+00:00</td>\n",
+       "      <td>2010-01-12 17:01:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-12</th>\n",
+       "      <td>2010-01-12 14:30:00+00:00</td>\n",
+       "      <td>2010-01-12 21:00:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-13</th>\n",
+       "      <td>2010-01-13 14:30:00+00:00</td>\n",
+       "      <td>2010-01-13 21:00:00+00:00</td>\n",
+       "      <td>2010-01-13 15:59:00+00:00</td>\n",
+       "      <td>2010-01-13 16:00:00+00:00</td>\n",
+       "      <td>2010-01-13 16:29:00+00:00</td>\n",
+       "      <td>2010-01-13 16:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-14</th>\n",
+       "      <td>2010-01-14 14:30:00+00:00</td>\n",
+       "      <td>2010-01-14 21:00:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-15</th>\n",
+       "      <td>2010-01-15 14:30:00+00:00</td>\n",
+       "      <td>2010-01-15 21:00:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         market_open              market_close  \\\n",
+       "2010-01-11 2010-01-11 14:30:00+00:00 2010-01-11 21:00:00+00:00   \n",
+       "2010-01-12 2010-01-12 14:30:00+00:00 2010-01-12 21:00:00+00:00   \n",
+       "2010-01-13 2010-01-13 14:30:00+00:00 2010-01-13 21:00:00+00:00   \n",
+       "2010-01-14 2010-01-14 14:30:00+00:00 2010-01-14 21:00:00+00:00   \n",
+       "2010-01-15 2010-01-15 14:30:00+00:00 2010-01-15 21:00:00+00:00   \n",
+       "\n",
+       "                interruption_start_1        interruption_end_1  \\\n",
+       "2010-01-11 2010-01-11 17:00:00+00:00 2010-01-12 17:01:00+00:00   \n",
+       "2010-01-12                       NaT                       NaT   \n",
+       "2010-01-13 2010-01-13 15:59:00+00:00 2010-01-13 16:00:00+00:00   \n",
+       "2010-01-14                       NaT                       NaT   \n",
+       "2010-01-15                       NaT                       NaT   \n",
+       "\n",
+       "                interruption_start_2        interruption_end_2  \n",
+       "2010-01-11                       NaT                       NaT  \n",
+       "2010-01-12                       NaT                       NaT  \n",
+       "2010-01-13 2010-01-13 16:29:00+00:00 2010-01-13 16:30:00+00:00  \n",
+       "2010-01-14                       NaT                       NaT  \n",
+       "2010-01-15                       NaT                       NaT  "
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sched = cal.schedule(\"2010-01-09\", \"2010-01-15\", interruptions= True)\n",
+    "sched"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def is_open(c, s, *dates):\n",
+    "    for t in dates:\n",
+    "        print(\"open on\", t, \":\", c.open_at_time(s, t))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Any *market_time* in `regular_market_times` can have special times, which are looked for in two properties:\n",
-    "* `special_{market_time}_adhoc`\n",
-    "    * same format as `special_opens_adhoc`, which is the same as `special_market_open_adhoc`\n",
-    "* `special_{market_time}`\n",
-    "    * same format as `special_opens`, which  is the same as `special_market_open`\n"
+    "#### Advanced open_at_time\n",
+    "\n",
+    "`MarketCalendar.open_at_time` uses the class attribute `open_close_map` to determine if a market_time opens or closes the market. It will also look for the 'interruption_' prefix in the columns to respect interruptions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "Here you can see that MarketCalendar.open_at_time respects interruptions (the last two timestamps):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "open on 2010-01-12 14:00:00 : False\n",
+      "open on 2010-01-12 14:35:00 : True\n",
+      "open on 2010-01-13 15:59:00 : False\n",
+      "open on 2010-01-13 16:30:00 : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "is_open(cal, sched, \"2010-01-12 14:00:00\", \"2010-01-12 14:35:00\",\"2010-01-13 15:59:00\",\"2010-01-13 16:30:00\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Advanced Usage"
+    "In the `DemoOptionsCalendar`, we did not specify what order_acceptance means for the market, which will not allow open_at_time to work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You seem to be using a schedule that isn't based on the market_times, or includes market_times that are not represented in the open_close_map.\n"
+     ]
+    }
+   ],
+   "source": [
+    "sched = cal.schedule(\"2010-01-09\", \"2010-01-15\", start= \"order_acceptance\", interruptions= True)\n",
+    "try: \n",
+    "    cal.open_at_time(sched, \"2010-01-12\")\n",
+    "except ValueError as e: \n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ProtectedDict(\n",
+      "{'market_open': True,\n",
+      " 'market_close': False,\n",
+      " 'break_start': False,\n",
+      " 'break_end': True,\n",
+      " 'pre': True,\n",
+      " 'post': False}\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "# These are the defaults that every MarketCalendar has, which is still missing order_accpetance.\n",
+    "print(cal.open_close_map)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To correct the calendar we should include the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>order_acceptance</th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>market_close</th>\n",
+       "      <th>interruption_start_1</th>\n",
+       "      <th>interruption_end_1</th>\n",
+       "      <th>interruption_start_2</th>\n",
+       "      <th>interruption_end_2</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2010-01-11</th>\n",
+       "      <td>2010-01-11 13:30:00+00:00</td>\n",
+       "      <td>2010-01-11 14:30:00+00:00</td>\n",
+       "      <td>2010-01-11 21:00:00+00:00</td>\n",
+       "      <td>2010-01-11 17:00:00+00:00</td>\n",
+       "      <td>2010-01-12 17:01:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-12</th>\n",
+       "      <td>2010-01-12 13:30:00+00:00</td>\n",
+       "      <td>2010-01-12 14:30:00+00:00</td>\n",
+       "      <td>2010-01-12 21:00:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-13</th>\n",
+       "      <td>2010-01-13 13:30:00+00:00</td>\n",
+       "      <td>2010-01-13 14:30:00+00:00</td>\n",
+       "      <td>2010-01-13 21:00:00+00:00</td>\n",
+       "      <td>2010-01-13 15:59:00+00:00</td>\n",
+       "      <td>2010-01-13 16:00:00+00:00</td>\n",
+       "      <td>2010-01-13 16:29:00+00:00</td>\n",
+       "      <td>2010-01-13 16:30:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-14</th>\n",
+       "      <td>2010-01-14 13:30:00+00:00</td>\n",
+       "      <td>2010-01-14 14:30:00+00:00</td>\n",
+       "      <td>2010-01-14 21:00:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-15</th>\n",
+       "      <td>2010-01-15 13:30:00+00:00</td>\n",
+       "      <td>2010-01-15 14:30:00+00:00</td>\n",
+       "      <td>2010-01-15 21:00:00+00:00</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    order_acceptance               market_open  \\\n",
+       "2010-01-11 2010-01-11 13:30:00+00:00 2010-01-11 14:30:00+00:00   \n",
+       "2010-01-12 2010-01-12 13:30:00+00:00 2010-01-12 14:30:00+00:00   \n",
+       "2010-01-13 2010-01-13 13:30:00+00:00 2010-01-13 14:30:00+00:00   \n",
+       "2010-01-14 2010-01-14 13:30:00+00:00 2010-01-14 14:30:00+00:00   \n",
+       "2010-01-15 2010-01-15 13:30:00+00:00 2010-01-15 14:30:00+00:00   \n",
+       "\n",
+       "                        market_close      interruption_start_1  \\\n",
+       "2010-01-11 2010-01-11 21:00:00+00:00 2010-01-11 17:00:00+00:00   \n",
+       "2010-01-12 2010-01-12 21:00:00+00:00                       NaT   \n",
+       "2010-01-13 2010-01-13 21:00:00+00:00 2010-01-13 15:59:00+00:00   \n",
+       "2010-01-14 2010-01-14 21:00:00+00:00                       NaT   \n",
+       "2010-01-15 2010-01-15 21:00:00+00:00                       NaT   \n",
+       "\n",
+       "                  interruption_end_1      interruption_start_2  \\\n",
+       "2010-01-11 2010-01-12 17:01:00+00:00                       NaT   \n",
+       "2010-01-12                       NaT                       NaT   \n",
+       "2010-01-13 2010-01-13 16:00:00+00:00 2010-01-13 16:29:00+00:00   \n",
+       "2010-01-14                       NaT                       NaT   \n",
+       "2010-01-15                       NaT                       NaT   \n",
+       "\n",
+       "                  interruption_end_2  \n",
+       "2010-01-11                       NaT  \n",
+       "2010-01-12                       NaT  \n",
+       "2010-01-13 2010-01-13 16:30:00+00:00  \n",
+       "2010-01-14                       NaT  \n",
+       "2010-01-15                       NaT  "
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class OpenCloseDemo(InterruptionsDemo):\n",
+    "    \n",
+    "    open_close_map = {**CFEExchangeCalendar.open_close_map, \n",
+    "                     \"order_acceptance\": True}  \n",
+    "\n",
+    "cal = OpenCloseDemo()\n",
+    "\n",
+    "sched = cal.schedule(\"2010-01-09\", \"2010-01-15\", start= \"order_acceptance\", interruptions= True)\n",
+    "sched"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can see that not only interruptions (last two) but also order_acceptance (first) is respected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "open on 2010-01-11 13:35:00 : True\n",
+      "open on 2010-01-12 14:35:00 : True\n",
+      "open on 2010-01-13 15:59:00 : False\n",
+      "open on 2010-01-13 16:30:00 : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "is_open(cal, sched, \"2010-01-11 13:35:00\", \"2010-01-12 14:35:00\", \"2010-01-13 15:59:00\", \"2010-01-13 16:30:00\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can even change this dynamically, using the `opens` keyword in `.change_time` and `.add_time`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "open on 2010-01-11 13:35:00 : False\n",
+      "open on 2010-01-12 14:35:00 : True\n",
+      "open on 2010-01-13 15:59:00 : False\n",
+      "open on 2010-01-13 16:30:00 : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "cal.change_time(\"order_acceptance\", cal[\"order_acceptance\"], opens= False)\n",
+    "\n",
+    "is_open(cal, sched, \"2010-01-11 13:35:00\", \"2010-01-12 14:35:00\", \"2010-01-13 15:59:00\", \"2010-01-13 16:30:00\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>order_acceptance</th>\n",
+       "      <th>order_closed</th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>market_close</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2010-01-11</th>\n",
+       "      <td>2010-01-11 13:30:00+00:00</td>\n",
+       "      <td>2010-01-11 14:00:00+00:00</td>\n",
+       "      <td>2010-01-11 14:30:00+00:00</td>\n",
+       "      <td>2010-01-11 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-12</th>\n",
+       "      <td>2010-01-12 13:30:00+00:00</td>\n",
+       "      <td>2010-01-12 14:00:00+00:00</td>\n",
+       "      <td>2010-01-12 14:30:00+00:00</td>\n",
+       "      <td>2010-01-12 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-13</th>\n",
+       "      <td>2010-01-13 13:30:00+00:00</td>\n",
+       "      <td>2010-01-13 14:00:00+00:00</td>\n",
+       "      <td>2010-01-13 14:30:00+00:00</td>\n",
+       "      <td>2010-01-13 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-14</th>\n",
+       "      <td>2010-01-14 13:30:00+00:00</td>\n",
+       "      <td>2010-01-14 14:00:00+00:00</td>\n",
+       "      <td>2010-01-14 14:30:00+00:00</td>\n",
+       "      <td>2010-01-14 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2010-01-15</th>\n",
+       "      <td>2010-01-15 13:30:00+00:00</td>\n",
+       "      <td>2010-01-15 14:00:00+00:00</td>\n",
+       "      <td>2010-01-15 14:30:00+00:00</td>\n",
+       "      <td>2010-01-15 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    order_acceptance              order_closed  \\\n",
+       "2010-01-11 2010-01-11 13:30:00+00:00 2010-01-11 14:00:00+00:00   \n",
+       "2010-01-12 2010-01-12 13:30:00+00:00 2010-01-12 14:00:00+00:00   \n",
+       "2010-01-13 2010-01-13 13:30:00+00:00 2010-01-13 14:00:00+00:00   \n",
+       "2010-01-14 2010-01-14 13:30:00+00:00 2010-01-14 14:00:00+00:00   \n",
+       "2010-01-15 2010-01-15 13:30:00+00:00 2010-01-15 14:00:00+00:00   \n",
+       "\n",
+       "                         market_open              market_close  \n",
+       "2010-01-11 2010-01-11 14:30:00+00:00 2010-01-11 21:00:00+00:00  \n",
+       "2010-01-12 2010-01-12 14:30:00+00:00 2010-01-12 21:00:00+00:00  \n",
+       "2010-01-13 2010-01-13 14:30:00+00:00 2010-01-13 21:00:00+00:00  \n",
+       "2010-01-14 2010-01-14 14:30:00+00:00 2010-01-14 21:00:00+00:00  \n",
+       "2010-01-15 2010-01-15 14:30:00+00:00 2010-01-15 21:00:00+00:00  "
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cal.change_time(\"order_acceptance\", cal[\"order_acceptance\"], opens= True)\n",
+    "\n",
+    "cal.add_time(\"order_closed\", time(8), opens= False)\n",
+    "\n",
+    "sched = cal.schedule(\"2010-01-09\", \"2010-01-15\", start= \"order_acceptance\")\n",
+    "sched"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "open on 2010-01-11 13:35:00 : True\n",
+      "open on 2010-01-11 14:15:00 : False\n",
+      "open on 2010-01-11 14:35:00 : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "is_open(cal, sched, \"2010-01-11 13:35:00\", \"2010-01-11 14:15:00\", \"2010-01-11 14:35:00\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extra Usage"
    ]
   },
   {
@@ -1566,7 +2258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -1580,7 +2272,7 @@
        " Index: [])"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1598,7 +2290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -1646,7 +2338,7 @@
        "2000-12-27 2000-12-27 21:00:00+00:00  "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1664,7 +2356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -1704,7 +2396,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1715,7 +2407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -1787,7 +2479,7 @@
        "2000-12-28 2000-12-28 21:00:00+00:00  "
       ]
      },
-     "execution_count": 34,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1805,7 +2497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -1814,7 +2506,7 @@
        "False"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1825,7 +2517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1834,7 +2526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -1843,7 +2535,7 @@
        "(True, False, True)"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1861,7 +2553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
@@ -1871,7 +2563,7 @@
        " datetime.time(16, 0, tzinfo=<DstTzInfo 'America/New_York' LMT-1 day, 19:04:00 STD>))"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1882,7 +2574,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -1892,7 +2584,7 @@
        " datetime.time(4, 0, tzinfo=<DstTzInfo 'America/New_York' LMT-1 day, 19:04:00 STD>))"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1903,7 +2595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -1913,7 +2605,7 @@
        " datetime.time(15, 30, tzinfo=<DstTzInfo 'America/New_York' LMT-1 day, 19:04:00 STD>))"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1932,7 +2624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -1941,7 +2633,7 @@
        "datetime.time(9, 30, tzinfo=<DstTzInfo 'America/New_York' LMT-1 day, 19:04:00 STD>)"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1952,7 +2644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -1961,7 +2653,7 @@
        "((None, datetime.time(10, 0)), ('1985-01-01', datetime.time(9, 30)))"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1972,7 +2664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -1981,7 +2673,7 @@
        "datetime.time(10, 0, tzinfo=<DstTzInfo 'America/New_York' LMT-1 day, 19:04:00 STD>)"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1999,7 +2691,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
@@ -2008,7 +2700,7 @@
        "datetime.time(20, 0, tzinfo=<DstTzInfo 'America/New_York' LMT-1 day, 19:04:00 STD>)"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2020,7 +2712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -2046,16 +2738,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "DatetimeIndex(['2000-12-27 14:30:00+00:00', '2001-12-27 14:30:00+00:00'], dtype='datetime64[ns, UTC]', freq=None)"
+       "2000-12-27   2000-12-27 14:30:00+00:00\n",
+       "2001-12-27   2001-12-27 14:30:00+00:00\n",
+       "dtype: datetime64[ns, UTC]"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2073,15 +2767,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "..\\pandas_market_calendars\\market_calendar.py:128: UserWarning: ['break_start', 'break_end'] are discontinued, the dictionary `.discontinued_market_times` has the dates on which these were discontinued. The times as of those dates are incorrect, use .remove_time(market_time) to ignore a market_time.\n",
-      "  warnings.warn(f\"{list(self.discontinued_market_times.keys())} are discontinued, the dictionary\"\n"
+      "c:\\Code\\pandas_market_calendars\\examples\\..\\pandas_market_calendars\\market_calendar.py:144: UserWarning: ['break_start', 'break_end'] are discontinued, the dictionary `.discontinued_market_times` has the dates on which these were discontinued. The times as of those dates are incorrect, use .remove_time(market_time) to ignore a market_time.\n",
+      "  warnings.warn(f\"{list(discontinued.keys())} are discontinued, the dictionary\"\n"
      ]
     }
    ],
@@ -2091,7 +2785,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
@@ -2150,7 +2844,7 @@
        "2020-01-03 2020-01-03 04:00:00+00:00 2020-01-03 06:30:00+00:00  "
       ]
      },
-     "execution_count": 48,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2161,17 +2855,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'break_start': Timestamp('2000-05-22 00:00:00'),\n",
-       " 'break_end': Timestamp('2000-05-22 00:00:00')}"
+       "ProtectedDict({'break_start': Timestamp('2000-05-22 00:00:00'), 'break_end': Timestamp('2000-05-22 00:00:00')})"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2182,7 +2875,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -2203,7 +2896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -2252,7 +2945,7 @@
        "2020-01-03 2020-01-03 00:00:00+00:00 2020-01-03 06:30:00+00:00"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2280,7 +2973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
@@ -2292,7 +2985,7 @@
        "              dtype='datetime64[ns, UTC]', freq=None)"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2303,7 +2996,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
@@ -2332,7 +3025,7 @@
        "              dtype='datetime64[ns, UTC]', freq=None)"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2350,7 +3043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
@@ -2453,7 +3146,7 @@
        "2016-01-06 2016-01-06 14:30:00+00:00 2016-01-06 21:00:00+00:00"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2467,7 +3160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -2564,7 +3257,7 @@
        "2016-01-06 2016-01-06 08:00:00+00:00 2016-01-06 16:30:00+00:00"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2588,7 +3281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [
     {
@@ -2685,7 +3378,7 @@
        "2016-01-06 2016-01-06 14:30:00+00:00 2016-01-06 16:30:00+00:00"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2704,7 +3397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -2807,7 +3500,7 @@
        "2016-01-06 2016-01-06 08:00:00+00:00 2016-01-06 21:00:00+00:00"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2832,7 +3525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -2841,7 +3534,7 @@
        "numpy.datetime64('2020-05-26')"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2868,7 +3561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -2927,7 +3620,7 @@
        "2020-01-03 2020-01-03 21:30:00+00:00 2020-01-03 22:00:00+00:00  "
       ]
      },
-     "execution_count": 59,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2947,7 +3640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
@@ -2962,7 +3655,7 @@
        "              dtype='datetime64[ns, UTC]', freq=None)"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2982,9 +3675,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "pandas_market_calendars_venv",
+   "display_name": "mcal_venv",
    "language": "python",
-   "name": "pandas_market_calendars_venv"
+   "name": "mcal_venv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2996,7 +3689,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.5"
   },
   "toc-autonumbering": true,
   "toc-showtags": false

--- a/pandas_market_calendars/calendar_utils.py
+++ b/pandas_market_calendars/calendar_utils.py
@@ -54,7 +54,8 @@ class _date_range:
     """
     This is a callable class that should be used by calling the already initiated instance: `date_range`.
     Given a schedule, it will return a DatetimeIndex with all of the valid datetimes at the frequency given.
-    The schedule values are assumed to be in UTC.
+
+    The schedule columns should all have the same time zone.
 
     The calculations will be made for each trading session. If the passed schedule-DataFrame doesn't have
     breaks, there is one trading session per day going from market_open to market_close, otherwise there are two,

--- a/pandas_market_calendars/calendar_utils.py
+++ b/pandas_market_calendars/calendar_utils.py
@@ -5,6 +5,7 @@ import itertools
 import warnings
 
 import pandas as pd
+import numpy as np
 
 def merge_schedules(schedules, how='outer'):
     """
@@ -152,9 +153,8 @@ class _date_range:
 
         :param schedule: pd.DataFrame with first column: 'start' and second column: 'end'
         :return: pd.Series of float64"""
-        num_bars = (schedule.end - schedule.start) / self.frequency
-        remains = num_bars % 1    # round up, np.ceil-style
-        return num_bars.where(remains == 0, num_bars + 1 - remains).round()
+        return np.ceil((schedule.end - schedule.start) / self.frequency)
+
 
     def _calc_time_series(self, schedule):
         """Method used by date_range to calculate the trading index.
@@ -219,6 +219,6 @@ class _date_range:
         time_series = self._calc_time_series(schedule)
 
         time_series.name = None
-        return pd.DatetimeIndex(time_series.drop_duplicates(), tz= "UTC")
+        return pd.DatetimeIndex(time_series.drop_duplicates())
 
 date_range = _date_range()

--- a/pandas_market_calendars/class_registry.py
+++ b/pandas_market_calendars/class_registry.py
@@ -71,20 +71,23 @@ class ProtectedDict(dict):
         # __init__ is bypassed when unpickling, which causes __setitem__ to fail
         # without the _INIT_RAN_NORMALLY flag
         self._INIT_RAN_NORMALLY = True
-        self._ALLOW_SETTING_TIMES = False
+
+    def _set(self, key, value):
+        return super().__setitem__(key, value)
+
+    def _del(self, key):
+        return super().__delitem__(key)
 
     def __setitem__(self, key, value):
-        if not hasattr(self, "_INIT_RAN_NORMALLY") or self._ALLOW_SETTING_TIMES:
-            self._ALLOW_SETTING_TIMES = False
-            return super().__setitem__(key, value)
+        if not hasattr(self, "_INIT_RAN_NORMALLY"):
+            return self._set(key, value)
 
         raise TypeError("You cannot set a value directly, you can change regular_market_times "
                         "using .change_time, .add_time or .remove_time.")
 
     def __delitem__(self, key):
-        if not hasattr(self, "_INIT_RAN_NORMALLY") or self._ALLOW_SETTING_TIMES:
-            self._ALLOW_SETTING_TIMES = False
-            return super().__delitem__(key)
+        if not hasattr(self, "_INIT_RAN_NORMALLY"):
+            return self._del(key)
 
         raise TypeError("You cannot delete an item directly. You can change regular_market_times "
                         "using .change_time, .add_time or .remove_time")

--- a/pandas_market_calendars/class_registry.py
+++ b/pandas_market_calendars/class_registry.py
@@ -78,27 +78,25 @@ class ProtectedDict(dict):
             self._ALLOW_SETTING_TIMES = False
             return super().__setitem__(key, value)
 
-        raise TypeError("You cannot set a value directly, "
-                        "please use the instance methods MarketCalendar.change_time or "
-                        "MarketCalendar.add_time to alter the regular_market_times information, "
-                        "or inherit from MarketCalendar to create a new Class with custom times.")
+        raise TypeError("You cannot set a value directly, you can change regular_market_times "
+                        "using .change_time, .add_time or .remove_time.")
 
     def __delitem__(self, key):
         if not hasattr(self, "_INIT_RAN_NORMALLY") or self._ALLOW_SETTING_TIMES:
             self._ALLOW_SETTING_TIMES = False
             return super().__delitem__(key)
 
-        raise TypeError("You are not allowed to delete an item directly."
-                        "Pleas use the instance method MarketCalendar.remove_time.")
+        raise TypeError("You cannot delete an item directly. You can change regular_market_times "
+                        "using .change_time, .add_time or .remove_time")
 
     def __repr__(self):
         return self.__class__.__name__+ "(" + super().__repr__() + ")"
 
     def __str__(self):
         try:
-            formatted = pformat(self, sort_dicts= False) # sort_dicts apparently not available < python3.8
+            formatted = pformat(dict(self), sort_dicts= False) # sort_dicts apparently not available < python3.8
         except TypeError:
-            formatted = pformat(self)
+            formatted = pformat(dict(self))
 
         return self.__class__.__name__+ "(\n" + formatted + "\n)"
 

--- a/pandas_market_calendars/class_registry.py
+++ b/pandas_market_calendars/class_registry.py
@@ -54,7 +54,8 @@ class RegisteryMeta(type):
 
         super(RegisteryMeta, cls).__init__(name, bases, attr)
 
-        cls.regular_market_times = _ProtectedDict(cls.regular_market_times)
+        cls.regular_market_times = ProtectedDict(cls.regular_market_times)
+        cls.open_close_map = ProtectedDict(cls.open_close_map)
 
         cls.special_market_open = cls.special_opens
         cls.special_market_open_adhoc = cls.special_opens_adhoc
@@ -63,7 +64,7 @@ class RegisteryMeta(type):
         cls.special_market_close_adhoc = cls.special_closes_adhoc
 
 
-class _ProtectedDict(dict):
+class ProtectedDict(dict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pandas_market_calendars/exchange_calendar_nyse.py
+++ b/pandas_market_calendars/exchange_calendar_nyse.py
@@ -1104,9 +1104,9 @@ class NYSEExchangeCalendar(MarketCalendar):
         days = super().days_at_time(days, market_time, day_offset= day_offset)
 
         if market_time == "market_close" and not self.is_custom(market_time):
-            days = days.tz_convert(self.tz)
-            days = days.where(days.weekday != 5, days.normalize()+ self._tdelta(self._saturday_close))
-            days = days.tz_convert("UTC")
+            days = days.dt.tz_convert(self.tz)
+            days = days.where(days.dt.weekday != 5, days.dt.normalize()+ self._tdelta(self._saturday_close))
+            days = days.dt.tz_convert("UTC")
         return days
 
     def early_closes(self, schedule):

--- a/pandas_market_calendars/exchange_calendars_mirror.py
+++ b/pandas_market_calendars/exchange_calendars_mirror.py
@@ -31,14 +31,12 @@ class TradingCalendar(MarketCalendar):
         # offsets of exchange_calendar_mirrors are only available through the instance
         if cls._FINALIZE_TRADING_CALENDAR:
             if self._ec.open_offset:
-                cls.regular_market_times._ALLOW_SETTING_TIMES = True
-                cls.regular_market_times["market_open"] = tuple(
-                    (t[0], t[1], self._ec.open_offset) for t in cls.regular_market_times["market_open"])
+                cls.regular_market_times._set("market_open", tuple(
+                    (t[0], t[1], self._ec.open_offset) for t in cls.regular_market_times["market_open"]))
 
             if self._ec.close_offset:
-                cls.regular_market_times._ALLOW_SETTING_TIMES = True
-                cls.regular_market_times["market_close"] = tuple(
-                    (t[0], t[1], self._ec.close_offset) for t in cls.regular_market_times["market_close"])
+                cls.regular_market_times._set("market_close", tuple(
+                    (t[0], t[1], self._ec.close_offset) for t in cls.regular_market_times["market_close"]))
             cls._FINALIZE_TRADING_CALENDAR = False
 
         self.__init__(*args, **kwargs)

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -219,7 +219,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
         :param market_time: the market_time to add
         :param times: the time information
-        :param opens: see .add_time docstring
+        :param opens: see .change_time docstring
         :return: None
         """
         assert not market_time in self.regular_market_times, f"{market_time} is already in regular_market_times:" \

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -369,7 +369,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
     @property
     def interruptions_df(self):
         intr = self.interruptions
-        if not intr: return pd.DataFrame(index= pd.DatetimeIndex())
+        if not intr: return pd.DataFrame(index= pd.DatetimeIndex([]))
 
         intr = pd.DataFrame(intr, dtype="string")
         ix = intr.pop(0)
@@ -500,7 +500,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
 
     def schedule(self, start_date, end_date, tz='UTC', start= "market_open", end= "market_close",
-                 force_special_times= True, market_times= None):
+                 force_special_times= True, market_times= None, interruptions= False):
         """
         Generates the schedule DataFrame. The resulting DataFrame will have all the valid business days as the index
         and columns for the requested market times. The columns can be determined either by setting a range (inclusive
@@ -571,6 +571,11 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             adjusted = schedule.loc[_close_adj].apply(
                 lambda x: x.where(x.le(x["market_close"]), x["market_close"]), axis= 1)
             schedule.loc[_close_adj] = adjusted
+
+        if interruptions:
+            interrs = self.interruptions_df
+            schedule[interrs.columns] = interrs
+            schedule = schedule.dropna(how= "all", axis= 1)
 
         return schedule
 

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -619,7 +619,6 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
         if only_rth:
             lowest, highest = "market_open", "market_close"
-            cols = cols[cols.isin(self._get_market_times(lowest, highest)) | interrs]
         else:
             cols = cols[~interrs]
             ix = cols.map(self._market_times.index)
@@ -629,6 +628,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             raise ValueError("The provided timestamp is not covered by the schedule")
 
         day = schedule[schedule[lowest].le(timestamp)].iloc[-1].dropna().sort_values()
+        day = day.loc[lowest:highest]
         day = day.index.to_series(index= day)
 
         if interrs.any():

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -453,7 +453,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         :param days: DatetimeIndex An index of dates (represented as midnight).
         :param market_time: datetime.time The time to apply as an offset to each day in ``days``.
         :param day_offset: int The number of days we want to offset @days by
-        :return: DatetimeIndex of date with the time t
+        :return: pd.Series of date with the time t
         """
         # Offset days without tz to avoid timezone issues.
         days = pd.DatetimeIndex(days).tz_localize(None).to_series()

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -614,14 +614,9 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             if _adj_col:
                 # create an array of special times
                 special = self.special_dates(market_time, start_date, end_date, filter_holidays= False)
-
                 # overwrite standard times
                 specialix = special.index[special.index.isin(temp.index)] # some sources of special times don't exclude holidays
-                try: temp.loc[specialix] = special
-                except ValueError as e:
-                    raise ValueError("There seems to be a mistake in the special_times/holidays data,"
-                                     "most likely this stems from duplicate entries. You can use the .special_dates "
-                                     "method to inspect the data.") from e
+                temp.loc[specialix] = special
 
                 if _adj_others:
                     if market_time == "market_open": _open_adj = specialix

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -24,7 +24,7 @@ from .class_registry import RegisteryMeta, ProtectedDict
 
 MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY = range(7)
 
-class _DEFAULT: pass
+class DEFAULT: pass
 
 class MarketCalendarMeta(ABCMeta, RegisteryMeta):
     pass
@@ -174,7 +174,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
                 raise AssertionError("The passed time information is not in the right format, "
                                      "please consult the docs for how to set market times")
 
-        if opens is _DEFAULT:
+        if opens is DEFAULT:
             opens = self.__class__.open_close_map.get(market_time, None)
 
         if opens in (True, False):
@@ -184,8 +184,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             try: self.open_close_map._del(market_time)
             except KeyError: pass
         else:
-            raise ValuerError("when you pass `opens`, it needs to be True, False, or None")
-
+            raise ValueError("when you pass `opens`, it needs to be True, False, or None")
 
         self.regular_market_times._set(market_time, times)
 
@@ -195,7 +194,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         self._prepare_regular_market_times()
 
 
-    def change_time(self, market_time, times, opens= _DEFAULT):
+    def change_time(self, market_time, times, opens= DEFAULT):
         """
         Changes the specified market time in regular_market_times and makes the necessary adjustments.
 
@@ -205,14 +204,16 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             this is only needed if the market_time should be respected by .open_at_time
             True: opens
             False: closes
-            None: consider it neither opening nor closing (ignore in .open_at_time)
+            None: consider it neither opening nor closing, don't add to open_close_map (ignore in .open_at_time)
+            DEFAULT: same as None, unless the market_time is in self.__class__.open_close_map. Then it will take
+                the default value as defined by the class.
         :return: None
         """
         assert market_time in self.regular_market_times, f"{market_time} is not in regular_market_times:" \
                                                          f"\n{self._market_times}."
         return self._set_time(market_time, times, opens)
 
-    def add_time(self, market_time, times, opens= _DEFAULT):
+    def add_time(self, market_time, times, opens= DEFAULT):
         """
         Adds the specified market time to regular_market_times and makes the necessary adjustments.
 

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -411,7 +411,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         :param tz: time zone in either string or pytz.timezone
         :return: DatetimeIndex of valid business days
         """
-        return pd.date_range(start_date, end_date, freq=self.holidays(), normalize=True, tz=tz)
+        return pd.date_range(start_date, end_date, freq=self.holidays(), normalize=True, tz= tz)
 
     def _get_market_times(self, start, end):
         start = self._market_times.index(start)
@@ -493,7 +493,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         special = self._special_dates(calendars, ad_hoc, start_date, end_date)
 
         if filter_holidays:
-            valid = self.valid_days(start_date, end_date)
+            valid = self.valid_days(start_date, end_date, tz= None)
             special = special[special.index.isin(valid)]  # some sources of special times don't exclude holidays
         return special
 

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -123,6 +123,9 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         for market_time, times in self.regular_market_times.items():
             # in case a market_time has been discontinued, extend the last time
             # and add it to the discontinued_market_times dictionary
+            if market_time.startswith("interruption_"):
+                raise ValueError("'interruption_' prefix is reserved")
+
             if times[-1][1] is None:
                 self.discontinued_market_times[market_time] = times[-1][0]
                 times = times[:-1]

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -369,10 +369,11 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
     @property
     def interruptions_df(self):
         intr = self.interruptions
-        if not intr: return pd.DataFrame()
+        if not intr: return pd.DataFrame(index= pd.DatetimeIndex())
 
         intr = pd.DataFrame(intr, dtype="string")
         ix = intr.pop(0)
+        ix.name = None
 
         columns = []
         for i in range(1, intr.shape[1] // 2 + 1):

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -1,9 +1,10 @@
 from abc import ABCMeta, abstractmethod
 from datetime import time
+from pprint import pformat
 
 import pytest
 
-from pandas_market_calendars.class_registry import RegisteryMeta
+from pandas_market_calendars.class_registry import RegisteryMeta, ProtectedDict
 
 
 def test_inheritance():
@@ -132,6 +133,25 @@ def test_metamixing():
             return "test"
 
     assert Base.factory("Class2").test() == "test"
+
+
+def test_protected_dict():
+
+    dct = ProtectedDict(dict(a= 1, b= 2))
+
+    with pytest.raises(TypeError):
+        dct["a"] = 2
+
+    with pytest.raises(TypeError):
+        del dct["b"]
+
+    del dct._INIT_RAN_NORMALLY
+    del dct["b"]
+
+    dct = ProtectedDict(dict(a=1, b=2))
+
+    s = "ProtectedDict(\n" + pformat(dict(dct), sort_dicts= False) + "\n)"
+    assert str(dct) == s
 
 
 # if __name__ == '__main__':

--- a/tests/test_class_registry.py
+++ b/tests/test_class_registry.py
@@ -12,6 +12,7 @@ def test_inheritance():
             "market_open": {None: time(0)},
             "market_close": {None: time(23)}
         }
+        open_close_map = {}
         @classmethod
         def _prepare_regular_market_times(cls): return
 
@@ -96,6 +97,7 @@ def test_metamixing():
             "market_open": {None: time(0)},
             "market_close": {None: time(23)}
         }
+        open_close_map = {}
         @classmethod
         def _prepare_regular_market_times(cls): return
         def special_opens(self): return []

--- a/tests/test_iex_calendar.py
+++ b/tests/test_iex_calendar.py
@@ -3,7 +3,7 @@ import numpy as np
 from datetime import time 
 from pytz import timezone 
 from pandas_market_calendars.exchange_calendar_iex import IEXExchangeCalendar
-from pandas_market_calendars.class_registry import _ProtectedDict 
+from pandas_market_calendars.class_registry import ProtectedDict
 
 iex = IEXExchangeCalendar()
 
@@ -19,7 +19,7 @@ def test_open_close():
 
 def test_calendar_utility():
     assert len(iex.holidays().holidays) > 0
-    assert isinstance(iex.regular_market_times, _ProtectedDict)
+    assert isinstance(iex.regular_market_times, ProtectedDict)
     
     valid_days = iex.valid_days(start_date='2016-12-20', end_date='2017-01-10')
     assert isinstance(valid_days, pd.DatetimeIndex)

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -26,6 +26,7 @@ from pandas.tseries.holiday import AbstractHolidayCalendar
 from pandas_market_calendars import get_calendar, get_calendar_names
 from pandas_market_calendars.holidays_us import (Christmas, HurricaneSandyClosings, MonTuesThursBeforeIndependenceDay,
                                                  USNationalDaysofMourning, USNewYearsDay)
+from pandas_market_calendars.holidays_nyse import Sept11Anniversary12pmLateOpen2002
 from pandas_market_calendars.market_calendar import MarketCalendar #, clean_dates, days_at_time
 from pandas_market_calendars.exchange_calendars_mirror import TradingCalendar
 from pandas_market_calendars.exchange_calendar_nyse import NYSEExchangeCalendar
@@ -59,7 +60,7 @@ class FakeCalendar(MarketCalendar):
     @property
     def special_opens(self):
         return [(time(11, 15), AbstractHolidayCalendar(rules=[MonTuesThursBeforeIndependenceDay])),
-                 ((time(23), -1), AbstractHolidayCalendar(rules=[Christmas]))]
+                 ((time(23), -1), AbstractHolidayCalendar(rules=[Sept11Anniversary12pmLateOpen2002]))]
 
     @property
     def special_opens_adhoc(self):
@@ -693,8 +694,14 @@ def test_special_opens():
     assert pd.Timestamp('2012-07-04 11:13', tz='Asia/Ulaanbaatar').tz_convert('UTC') in opens
 
 
-    results = cal.schedule('2012-07-01', '2012-07-06')
-    opens = results['market_open'].tolist()
+    results = cal.schedule("2002-09-10", "2002-09-12", tz= cal.tz).market_open
+
+    goal = pd.Series(['2002-09-10 11:13:00+09:00', '2002-09-10 23:00:00+09:00', '2002-09-12 11:13:00+09:00'],
+                     index= pd.DatetimeIndex(['2002-09-10', '2002-09-11', '2002-09-12']),
+                     dtype= 'datetime64[ns, Asia/Ulaanbaatar]', name= "market_open")
+
+    assert_series_equal(results, goal)
+
 
 
 def test_special_opens_adhoc():

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -857,10 +857,9 @@ def test_open_at_time():
     cal.change_time("pre", time(7)) # is the day before in UTC
     cal.add_time("post", (time(9), 1))
     schedule = cal.schedule('2014-07-01', '2014-07-10', market_times= "all")
-    print(schedule.to_string())
     assert cal.open_at_time(schedule, pd.Timestamp("2014-07-03 23:30:00+00:00")) is True
     assert cal.open_at_time(schedule, pd.Timestamp("2014-07-05 00:30:00+00:00")) is True
-    # assert cal.open_at_time(schedule, pd.Timestamp("2014-07-05 00:30:00+00:00"), only_rth= True) is False
+    assert cal.open_at_time(schedule, pd.Timestamp("2014-07-05 00:30:00+00:00"), only_rth= True) is False
 
     cal.change_time("market_open", (cal.open_time, -2))
     cal.change_time("market_close", (cal.close_time, 3))
@@ -970,23 +969,11 @@ def test_open_at_time_interruptions():
     assert cal.open_at_time(sched, "2010-01-12 17:55:00", include_close=True) is True
     assert cal.open_at_time(sched, "2010-01-12 17:57:00", include_close=True) is False
 
-
-    print(sched.to_string())
-
-
-
-    # assert cal.open_at_time(sched, "2010-01-13 14:00:00", only_rth= True) is False
-    # assert cal.open_at_time(sched, "2010-01-13 14:30:00", only_rth= True) is False
-    # assert cal.open_at_time(sched, "2010-01-13 14:35:00", only_rth= True) is True
-    #
-    # assert cal.open_at_time(sched, "2010-01-13 16:03:00", only_rth= True) is True
-    # assert cal.open_at_time(sched, "2010-01-13 17:05:00", only_rth= True) is False
-
-
-
-
-
-
+    assert cal.open_at_time(sched, "2010-01-13 14:00:00", only_rth= True) is False
+    assert cal.open_at_time(sched, "2010-01-13 14:30:00", only_rth= True) is False
+    assert cal.open_at_time(sched, "2010-01-13 14:35:00", only_rth= True) is True
+    assert cal.open_at_time(sched, "2010-01-13 16:03:00", only_rth= True) is True
+    assert cal.open_at_time(sched, "2010-01-13 17:05:00", only_rth= True) is False
 
 def test_is_open_now(patch_get_current_time):
     cal = FakeCalendar()

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -58,19 +58,32 @@ class FakeCalendar(MarketCalendar):
 
     @property
     def special_opens(self):
-        return [(time(11, 15), AbstractHolidayCalendar(rules=[MonTuesThursBeforeIndependenceDay]))]
+        return [(time(11, 15), AbstractHolidayCalendar(rules=[MonTuesThursBeforeIndependenceDay])),
+                 ((time(23), -1), AbstractHolidayCalendar(rules=[Christmas]))]
 
     @property
     def special_opens_adhoc(self):
-        return [(time(11, 20), ['2016-12-13', "2016-12-25"])]
+        return [(time(11, 20), ["2016-12-13", "2016-12-25"]),
+                 ((time(22), -1), ["2016-12-09", "2016-12-07"])]
 
     @property
     def special_closes(self):
-        return [(time(11, 30), AbstractHolidayCalendar(rules=[MonTuesThursBeforeIndependenceDay]))]
+        return [(time(11, 30), AbstractHolidayCalendar(rules=[MonTuesThursBeforeIndependenceDay])),
+                 ((time(1), 1), AbstractHolidayCalendar(rules=[Christmas]))]
 
     @property
     def special_closes_adhoc(self):
-        return [(time(11, 40), ['2016-12-14'])]
+        return [(time(11, 40), ["2016-12-14"]),
+                ((time(1, 5), 1), ["2016-12-15"])]
+
+    @property
+    def interruptions(self):
+        return [
+            ("2011-01-10", time(11), time(11, 1)),
+            ("2010-01-11", time(11), time(11, 1)),
+            ("2003-09-11", time(9, 59), time(10), time(10, 29), time(10, 30)),
+            ("2002-02-03", time(11), time(11, 2))
+        ]
 
 
 class FakeBreakCalendar(MarketCalendar):
@@ -678,6 +691,10 @@ def test_special_opens():
     assert pd.Timestamp('2012-07-02 11:13', tz='Asia/Ulaanbaatar').tz_convert('UTC') in opens
     assert pd.Timestamp('2012-07-03 11:15', tz='Asia/Ulaanbaatar').tz_convert('UTC') in opens
     assert pd.Timestamp('2012-07-04 11:13', tz='Asia/Ulaanbaatar').tz_convert('UTC') in opens
+
+
+    results = cal.schedule('2012-07-01', '2012-07-06')
+    opens = results['market_open'].tolist()
 
 
 def test_special_opens_adhoc():

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -19,6 +19,7 @@ import pickle
 
 
 import pandas as pd
+import numpy as np
 import pytest
 from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 from pandas.tseries.holiday import AbstractHolidayCalendar
@@ -897,7 +898,6 @@ def test_is_open_now(patch_get_current_time):
 
     assert cal.is_open_now(schedule) is True
 
-
 def test_bad_dates():
     cal = FakeCalendar()
 
@@ -918,6 +918,34 @@ def test_bad_dates():
     # weekend and holiday
     schedule = cal.schedule('2017-12-30', '2018-01-01')
     assert_frame_equal(schedule, empty)
+
+def test_interruptions_df():
+
+    goal = pd.DataFrame(
+        {'interruption_start_1':
+             pd.Series(['2011-01-10 11:00:00', '2010-01-11 11:00:00',
+                        '2003-09-11 09:59:00', '2002-02-03 11:00:00'],
+                       index= pd.DatetimeIndex(['2011-01-10', '2010-01-11', '2003-09-11', '2002-02-03']),
+                       dtype= 'datetime64[ns]').dt.tz_localize('Asia/Ulaanbaatar'),
+         'interruption_end_1':
+             pd.Series(['2011-01-10 11:01:00', '2010-01-11 11:01:00',
+                        '2003-09-11 10:00:00', '2002-02-03 11:02:00'],
+                       index= pd.DatetimeIndex(['2011-01-10', '2010-01-11', '2003-09-11', '2002-02-03']),
+                       dtype= 'datetime64[ns]').dt.tz_localize('Asia/Ulaanbaatar'),
+         'interruption_start_2':
+             pd.Series([np.nan, np.nan, '2003-09-11 10:29:00', np.nan],
+                       index= pd.DatetimeIndex(['2011-01-10', '2010-01-11', '2003-09-11', '2002-02-03']),
+                       dtype= 'datetime64[ns]').dt.tz_localize('Asia/Ulaanbaatar'),
+         'interruption_end_2':
+             pd.Series([np.nan, np.nan, '2003-09-11 10:30:00', np.nan],
+                       index= pd.DatetimeIndex(['2011-01-10', '2010-01-11', '2003-09-11', '2002-02-03']),
+                       dtype= 'datetime64[ns]').dt.tz_localize('Asia/Ulaanbaatar')},
+        index= pd.DatetimeIndex(['2011-01-10', '2010-01-11', '2003-09-11', '2002-02-03']))
+
+    cal = FakeCalendar()
+    print(cal.interruptions_df.to_string())
+    assert_frame_equal(cal.interruptions_df, goal)
+
 
 ############################################
 # TESTS FOR EXCHANGE_CALENDAR INTEGRATION  #

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -70,12 +70,12 @@ class FakeCalendar(MarketCalendar):
     @property
     def special_closes(self):
         return [(time(11, 30), AbstractHolidayCalendar(rules=[MonTuesThursBeforeIndependenceDay])),
-                 ((time(1), 1), AbstractHolidayCalendar(rules=[Christmas]))]
+                 ((time(1), 1), AbstractHolidayCalendar(rules=[Sept11Anniversary12pmLateOpen2002]))]
 
     @property
     def special_closes_adhoc(self):
         return [(time(11, 40), ["2016-12-14"]),
-                ((time(1, 5), 1), ["2016-12-15"])]
+                ((time(1, 5), 1), ["2016-12-16"])]
 
     @property
     def interruptions(self):
@@ -715,6 +715,15 @@ def test_special_opens_adhoc():
     assert pd.Timestamp('2016-12-13 11:20', tz='Asia/Ulaanbaatar').tz_convert('UTC') in opens
     assert pd.Timestamp('2016-12-14 11:13', tz='Asia/Ulaanbaatar').tz_convert('UTC') in opens
 
+    results = cal.schedule("2016-12-06", "2016-12-10", tz= cal.tz).market_open
+
+    goal = pd.Series(['2016-12-06 11:13:00+08:00', '2016-12-06 22:00:00+08:00',
+                      '2016-12-08 11:13:00+08:00', '2016-12-08 22:00:00+08:00'],
+                     index= pd.DatetimeIndex(['2016-12-06', '2016-12-07', '2016-12-08', '2016-12-09']),
+                     dtype= 'datetime64[ns, Asia/Ulaanbaatar]', name= "market_open")
+
+    assert_series_equal(results, goal)
+
 
 def test_special_closes():
     cal = FakeCalendar()
@@ -741,6 +750,15 @@ def test_special_closes():
                 pd.Timestamp('2012-07-03 11:30', tz='Asia/Ulaanbaatar').tz_convert('UTC')]
     assert actual == expected
 
+    results = cal.schedule("2002-09-10", "2002-09-12", tz= cal.tz).market_close
+
+    goal = pd.Series(['2002-09-10 11:49:00+09:00', '2002-09-12 01:00:00+09:00', '2002-09-12 11:49:00+09:00'],
+                     index= pd.DatetimeIndex(['2002-09-10', '2002-09-11', '2002-09-12']),
+                     dtype= 'datetime64[ns, Asia/Ulaanbaatar]', name= "market_close")
+
+    assert_series_equal(results, goal)
+
+
 
 def test_special_closes_adhoc():
     cal = FakeCalendar()
@@ -758,6 +776,15 @@ def test_special_closes_adhoc():
     closes = results['market_close'].tolist()
     assert pd.Timestamp('2016-12-13 11:49', tz='Asia/Ulaanbaatar').tz_convert('UTC') in closes
     assert pd.Timestamp('2016-12-14 11:40', tz='Asia/Ulaanbaatar').tz_convert('UTC') in closes
+
+    results = cal.schedule('2016-12-13', '2016-12-19', cal.tz).market_close
+
+    goal = pd.Series(['2016-12-13 11:49:00+08:00', '2016-12-14 11:40:00+08:00',
+                      '2016-12-15 11:49:00+08:00', '2016-12-17 01:05:00+08:00', '2016-12-19 11:49:00+08:00'],
+                     index= pd.DatetimeIndex(['2016-12-13', '2016-12-14', '2016-12-15', '2016-12-16', '2016-12-19']),
+                     dtype= 'datetime64[ns, Asia/Ulaanbaatar]', name= "market_close")
+
+    assert_series_equal(results, goal)
 
 
 def test_early_closes():

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -138,9 +138,22 @@ def test_protected_dictionary(cal= None):
     with pytest.raises(TypeError) as e:
         cal.regular_market_times["market_open"] = time(12)
 
+    with pytest.raises(TypeError) as e:
+        cal.open_close_map["anything"] = time(12)
+
     # nor delete
     with pytest.raises(TypeError) as e:
         del cal.regular_market_times["market_open"]
+
+    with pytest.raises(TypeError) as e:
+        del cal.open_close_map["break_start"]
+
+def test_market_time_names():
+    cal = FakeCalendar()
+
+    with pytest.raises(ValueError):
+        cal.add_time("interruption_anything", time(11, 30))
+
 
 def test_pickling():
 

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -61,17 +61,17 @@ class FakeCalendar(MarketCalendar):
     @property
     def special_opens(self):
         return [(time(11, 15), AbstractHolidayCalendar(rules=[MonTuesThursBeforeIndependenceDay])),
-                 ((time(23), -1), AbstractHolidayCalendar(rules=[Sept11Anniversary12pmLateOpen2002]))]
+                ((time(23), -1), AbstractHolidayCalendar(rules=[Sept11Anniversary12pmLateOpen2002]))]
 
     @property
     def special_opens_adhoc(self):
         return [(time(11, 20), ["2016-12-13", "2016-12-25"]),
-                 ((time(22), -1), ["2016-12-09", "2016-12-07"])]
+                ((time(22), -1), ["2016-12-09", "2016-12-07"])]
 
     @property
     def special_closes(self):
         return [(time(11, 30), AbstractHolidayCalendar(rules=[MonTuesThursBeforeIndependenceDay])),
-                 ((time(1), 1), AbstractHolidayCalendar(rules=[Sept11Anniversary12pmLateOpen2002]))]
+                ((time(1), 1), AbstractHolidayCalendar(rules=[Sept11Anniversary12pmLateOpen2002]))]
 
     @property
     def special_closes_adhoc(self):
@@ -81,10 +81,10 @@ class FakeCalendar(MarketCalendar):
     @property
     def interruptions(self):
         return [
-            ("2011-01-10", time(11), time(11, 1)),
-            ("2010-01-13", time(9, 59), time(10), time(10, 29), time(10, 30)),
+            ("2002-02-03", (time(11), -1), time(11, 2)),
             ("2010-01-11", time(11), (time(11, 1), 1)),
-            ("2002-02-03", (time(11), -1), time(11, 2))
+            ("2010-01-13", time(9, 59), time(10), time(10, 29), time(10, 30)),
+            ("2011-01-10", time(11), time(11, 1))
         ]
 
 
@@ -167,6 +167,7 @@ def test_pickling():
         assert cal.market_times == unpickled.market_times
         assert cal.discontinued_market_times == unpickled.discontinued_market_times
         assert cal._regular_market_timedeltas == unpickled._regular_market_timedeltas
+        assert cal.open_close_map == unpickled.open_close_map
 
         test_protected_dictionary(cal)
         test_protected_dictionary(unpickled)
@@ -175,6 +176,7 @@ def test_pickling():
         pickled = pickle.dumps(Cal)
         unpickled = pickle.loads(pickled)
         assert Cal.regular_market_times == unpickled.regular_market_times
+        assert Cal.open_close_map == unpickled.open_close_map
 
         test_protected_dictionary(Cal)
         test_protected_dictionary(unpickled)
@@ -925,32 +927,7 @@ def test_open_at_time_breaks():
 
 def test_open_at_time_interruptions():
     cal = FakeBreakCalendar()
-
     sched = cal.schedule("2010-01-08", "2010-01-14", interruptions=True)
-
-    """
-    possibilities
-    
-     interruption between
-         market_open/break
-         break/market_close
-         pre/market_open
-         market_close/post
-         
-     multiple interruptions
-        
-     only_rth  True/False
-     
-     different timezones for passed timestamp and schedule
-     
-     timestamp between
-        interruptions
-        break
-        after post/market_close
-        
-    
-    """
-    print(sched.to_string())
 
     # No pre/post
     assert cal.open_at_time(sched, "2010-01-11 14:40:00") is True
@@ -1034,7 +1011,6 @@ def test_interruptions_df():
         }).set_index(pd.DatetimeIndex(['2002-02-03', '2010-01-11', '2010-01-13', '2011-01-10']))
 
     cal = FakeCalendar()
-    print(cal.interruptions_df.to_string())
     assert_frame_equal(cal.interruptions_df, goal)
 
 

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -154,7 +154,6 @@ def test_market_time_names():
     with pytest.raises(ValueError):
         cal.add_time("interruption_anything", time(11, 30))
 
-
 def test_pickling():
 
     for Cal in [FakeCalendar, FakeBreakCalendar, NYSEExchangeCalendar]:
@@ -883,7 +882,7 @@ def test_open_at_time():
     cal.change_time("market_close", (cal.close_time, 3))
     schedule = cal.schedule('2014-07-01', '2014-07-10', market_times= "all")
     assert cal.open_at_time(schedule, "2014-06-29 04:00:00+00:00") is True
-    assert cal.open_at_time(schedule, "2014-07-13 06:00:00+03:00") is True
+    assert cal.open_at_time(schedule, "2014-07-13 06:00:00+03:00") is False
 
     # should raise error if not all columns are in self.market_times
     with pytest.raises(ValueError):
@@ -959,8 +958,9 @@ def test_open_at_time_interruptions():
     # interruption between market_close/post
     sched.iloc[2, [-2, -1]] += pd.Timedelta("1H")
     assert cal.open_at_time(sched, "2010-01-12 17:56:00") is False
-    assert cal.open_at_time(sched, "2010-01-12 17:55:00", include_close=True) is True
+    assert cal.open_at_time(sched, "2010-01-12 17:55:00", include_close=True) is False
     assert cal.open_at_time(sched, "2010-01-12 17:57:00", include_close=True) is False
+    assert cal.open_at_time(sched, "2010-01-12 17:57:00", include_close=False) is True
 
     assert cal.open_at_time(sched, "2010-01-13 14:00:00", only_rth= True) is False
     assert cal.open_at_time(sched, "2010-01-13 14:30:00", only_rth= True) is False

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -154,6 +154,16 @@ def test_market_time_names():
     with pytest.raises(ValueError):
         cal.add_time("interruption_anything", time(11, 30))
 
+    class WrongCal(FakeCalendar):
+        regular_market_times = {**FakeCalendar.regular_market_times,
+                                "interruption_anything": True}
+
+    with pytest.raises(ValueError) as e: cal = WrongCal()
+
+    assert "'interruption_' prefix is reserved" in e.exconly(), e.exconly()
+
+    del WrongCal._regmeta_class_registry["WrongCal"]
+
 def test_pickling():
 
     for Cal in [FakeCalendar, FakeBreakCalendar, NYSEExchangeCalendar]:
@@ -322,6 +332,23 @@ def test_add_change_remove_time_w_open_close_map():
     with pytest.raises(ValueError):
         cal.change_time("market_close", time(15), opens= 2)
 
+def test_open_close_map():
+    cal = FakeCalendar()
+    assert FakeCalendar.open_close_map == {"market_open": True, "market_close": False,
+                                           "break_start": False, "break_end": True,
+                                           "pre": True, "post": False}
+    assert not cal.open_close_map is FakeCalendar.open_close_map
+    assert cal.open_close_map == FakeCalendar.open_close_map
+
+    class WrongCal(FakeCalendar):
+        open_close_map = {**FakeCalendar.open_close_map,
+                          "pre": None, "post": "string"}
+
+    with pytest.raises(AssertionError) as e: cal = WrongCal()
+
+    assert "Values in open_close_map need to be True or False" in str(e)
+
+    del WrongCal._regmeta_class_registry["WrongCal"]
 
 def test_dunder_methods():
     cal = FakeCalendar()

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -870,6 +870,7 @@ def test_open_at_time():
     cal.change_time("pre", time(7)) # is the day before in UTC
     cal.add_time("post", (time(9), 1))
     schedule = cal.schedule('2014-07-01', '2014-07-10', market_times= "all")
+    print(schedule.to_string())
     assert cal.open_at_time(schedule, pd.Timestamp("2014-07-03 23:30:00+00:00")) is True
     assert cal.open_at_time(schedule, pd.Timestamp("2014-07-05 00:30:00+00:00")) is True
     assert cal.open_at_time(schedule, pd.Timestamp("2014-07-05 00:30:00+00:00"), only_rth= True) is False

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -847,6 +847,9 @@ def test_open_at_time():
     schedule = cal.schedule('2014-01-01', '2016-12-31')
     # regular trading day
     assert cal.open_at_time(schedule, pd.Timestamp('2014-07-02 03:40', tz='UTC')) is True
+    assert cal.open_at_time(schedule, pd.Timestamp('2014-07-02 03:40')) is True
+    assert cal.open_at_time(schedule, pd.Timestamp('2014-07-02 03:40', tz='UTC'
+                                                   ).tz_convert("America/New_York")) is True
     # early close
     assert cal.open_at_time(schedule, pd.Timestamp('2014-07-03 03:40', tz='UTC')) is False
     # holiday

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pandas as pd
 import pytest
 import pytz
-from pandas.testing import assert_index_equal
+from pandas.testing import assert_index_equal, assert_series_equal
 
 from pandas_market_calendars.exchange_calendar_nyse import NYSEExchangeCalendar
 
@@ -17,93 +17,73 @@ def test_custom_open_close():
     assert not NYSEExchangeCalendar.regular_market_times is cal.regular_market_times
 
 
-@pytest.mark.xfail
-def test_days_at_time_open():
+
+@pytest.mark.parametrize("dates, results", [
+    (("1984-12-30", "1985-01-03"), ['1984-12-31 10:00:00', '1985-01-02 09:30:00', '1985-01-03 09:30:00']),
+    (("1901-12-13", "1901-12-16"), ['1901-12-13 10:00:00', '1901-12-14 10:00:00', '1901-12-16 10:00:00'])
+])
+def test_days_at_time_open(dates, results):
     cal = NYSEExchangeCalendar()
 
     # check if market_open before/after 1985 is correct
-    valid = cal.valid_days("1984-12-30", "1985-01-03")
+    valid = cal.valid_days(*dates)
     at_open = cal.days_at_time(valid, "market_open")
 
-    assert_index_equal(at_open, pd.DatetimeIndex(
-        ['1984-12-31 10:00:00', '1985-01-02 09:30:00',
-         '1985-01-03 09:30:00'], dtype='datetime64[ns]', freq=None
-    ).tz_localize(cal.tz).tz_convert("UTC"))
+    assert_series_equal(at_open, pd.Series(
+        results, index= pd.DatetimeIndex(results).normalize(), dtype= "datetime64[ns]"
+    ).dt.tz_localize(cal.tz).dt.tz_convert("UTC"))
 
-    # check if it is rounded
-    valid = cal.valid_days("1901-12-13", "1901-12-16")
-    at_open = cal.days_at_time(valid, "market_open")
 
-    assert_index_equal(at_open, pd.DatetimeIndex(
-        ['1901-12-13 10:00:00', '1901-12-14 10:00:00',
-         '1901-12-16 10:00:00'], dtype='datetime64[ns]', freq=None
-    ).tz_localize(cal.tz).tz_convert("UTC"))
-
-    # check if chosen time is kept
-    cal = NYSEExchangeCalendar(open_time=dt.time(9))
-    at_open = cal.days_at_time(valid, "market_open")
-
-    assert_index_equal(at_open, pd.DatetimeIndex(
-        ['1901-12-13 09:00:00', '1901-12-14 09:00:00',
-         '1901-12-16 09:00:00'], dtype='datetime64[ns]', freq=None
-    ).tz_localize(cal.tz).tz_convert("UTC"))
-
-@pytest.mark.xfail
-def test_days_at_time_close():
+@pytest.mark.parametrize("dates, results", [
+    (("1952-09-26", "1952-09-30"), ['1952-09-26 15:00:00', '1952-09-29 15:30:00', '1952-09-30 15:30:00']),
+    (("1973-12-28", "1974-01-02"), ['1973-12-28 15:30:00', '1973-12-31 15:30:00', '1974-01-02 16:00:00']),
+    (("1952-05-23", "1952-05-26"), ['1952-05-23 15:00:00', '1952-05-24 12:00:00', '1952-05-26 15:00:00']),
+    (("1901-12-13", "1901-12-16"), ['1901-12-13 15:00:00', '1901-12-14 12:00:00', '1901-12-16 15:00:00']),
+])
+def test_days_at_time_close(dates, results):
     cal = NYSEExchangeCalendar()
-
     # test market_close before/after 1952-09-29
-    valid = cal.valid_days("1952-09-26", "1952-09-30")
+    valid = cal.valid_days(*dates)
     at_close = cal.days_at_time(valid, "market_close")
 
-    assert_index_equal(at_close, pd.DatetimeIndex(
-        ['1952-09-26 15:00:00', '1952-09-29 15:30:00',
-         '1952-09-30 15:30:00'], dtype='datetime64[ns]', freq=None
-    ).tz_localize(cal.tz).tz_convert("UTC"))
+    print(at_close)
+    print(pd.Series(
+        results, index= pd.DatetimeIndex(results, freq= None).normalize(), dtype= "datetime64[ns]",
+    ).dt.tz_localize(cal.tz).dt.tz_convert("UTC"))
 
-    # market_close before/after 1974-01-01
-    valid = cal.valid_days("1973-12-28", "1974-01-02")
-    at_close = cal.days_at_time(valid, "market_close")
-    assert_index_equal(at_close, pd.DatetimeIndex(
-        ['1973-12-28 15:30:00', '1973-12-31 15:30:00',
-         '1974-01-02 16:00:00'], dtype='datetime64[ns]', freq=None
-    ).tz_localize(cal.tz).tz_convert("UTC"))
+    assert_series_equal(at_close, pd.Series(
+        results, index= pd.DatetimeIndex(results).normalize(), dtype= "datetime64[ns]"
+    ).dt.tz_localize(cal.tz).dt.tz_convert("UTC"))
+
+def test_days_at_time_custom():
+    cal = NYSEExchangeCalendar()
 
     # test all three market_closes
     valid = cal.valid_days("1952-09-26", "1974-01-02")
-    at_close = cal.days_at_time(valid, "market_close").tz_convert(cal.tz)
+    at_close = cal.days_at_time(valid, "market_close").dt.tz_convert(cal.tz)
 
-    assert at_close[0] == pd.Timestamp('1952-09-26 15:00:00').tz_localize(cal.tz)
-    assert at_close[1] == pd.Timestamp('1952-09-29 15:30:00').tz_localize(cal.tz)
-    assert at_close[-2] == pd.Timestamp('1973-12-31 15:30:00').tz_localize(cal.tz)
-    assert at_close[-1] == pd.Timestamp('1974-01-02 16:00:00').tz_localize(cal.tz)
-
-    # test Saturday closes
-    valid = cal.valid_days("1952-05-23", "1952-05-26")
-    at_close = cal.days_at_time(valid, "market_close")
-
-    assert_index_equal(at_close, pd.DatetimeIndex(
-        ['1952-05-23 15:00:00', '1952-05-24 12:00:00',
-         '1952-05-26 15:00:00'], dtype='datetime64[ns]', freq=None
-    ).tz_localize(cal.tz).tz_convert("UTC"))
-
-    # check if it is rounded
-    valid = cal.valid_days("1901-12-13", "1901-12-16")
-    at_close = cal.days_at_time(valid, "market_close")
-
-    assert_index_equal(at_close, pd.DatetimeIndex(
-        ['1901-12-13 15:00:00', '1901-12-14 12:00:00',
-         '1901-12-16 15:00:00'], dtype='datetime64[ns]', freq=None
-    ).tz_localize(cal.tz).tz_convert("UTC"))
+    assert at_close.iat[0] == pd.Timestamp('1952-09-26 15:00:00').tz_localize(cal.tz)
+    assert at_close.iat[1] == pd.Timestamp('1952-09-29 15:30:00').tz_localize(cal.tz)
+    assert at_close.iat[-2] == pd.Timestamp('1973-12-31 15:30:00').tz_localize(cal.tz)
+    assert at_close.iat[-1] == pd.Timestamp('1974-01-02 16:00:00').tz_localize(cal.tz)
 
     # check if chosen time is kept
     cal = NYSEExchangeCalendar(close_time=dt.time(10))
-    at_close = cal.days_at_time(valid, "market_close")
+    at_close = cal.days_at_time(cal.valid_days("1901-12-13", "1901-12-16"), "market_close")
 
-    assert_index_equal(at_close, pd.DatetimeIndex(
-        ['1901-12-13 10:00:00', '1901-12-14 10:00:00',
-         '1901-12-16 10:00:00'], dtype='datetime64[ns]', freq=None
-    ).tz_localize(cal.tz).tz_convert("UTC"))
+    results = pd.DatetimeIndex(['1901-12-13 10:00:00', '1901-12-14 10:00:00', '1901-12-16 10:00:00'])
+    assert_series_equal(at_close,
+                        pd.Series(results.tz_localize(cal.tz).tz_convert("UTC"),
+                        index= results.normalize()))
+
+    # check if chosen time is kept
+    cal = NYSEExchangeCalendar(open_time=dt.time(9))
+    at_open = cal.days_at_time(cal.valid_days("1901-12-13", "1901-12-16"), "market_open")
+
+    results = pd.DatetimeIndex(['1901-12-13 09:00:00', '1901-12-14 09:00:00', '1901-12-16 09:00:00'])
+    assert_series_equal(at_open,
+                        pd.Series(results.tz_localize(cal.tz).tz_convert("UTC"),
+                        index= results.normalize()))
 
 
 def test_time_zone():

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -1,6 +1,7 @@
 import os
 import datetime as dt
 import pandas as pd
+import pytest
 import pytz
 from pandas.testing import assert_index_equal
 
@@ -16,7 +17,7 @@ def test_custom_open_close():
     assert not NYSEExchangeCalendar.regular_market_times is cal.regular_market_times
 
 
-
+@pytest.mark.xfail
 def test_days_at_time_open():
     cal = NYSEExchangeCalendar()
 
@@ -47,7 +48,7 @@ def test_days_at_time_open():
          '1901-12-16 09:00:00'], dtype='datetime64[ns]', freq=None
     ).tz_localize(cal.tz).tz_convert("UTC"))
 
-
+@pytest.mark.xfail
 def test_days_at_time_close():
     cal = NYSEExchangeCalendar()
 

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -16,8 +16,6 @@ def test_custom_open_close():
 
     assert not NYSEExchangeCalendar.regular_market_times is cal.regular_market_times
 
-
-
 @pytest.mark.parametrize("dates, results", [
     (("1984-12-30", "1985-01-03"), ['1984-12-31 10:00:00', '1985-01-02 09:30:00', '1985-01-03 09:30:00']),
     (("1901-12-13", "1901-12-16"), ['1901-12-13 10:00:00', '1901-12-14 10:00:00', '1901-12-16 10:00:00'])
@@ -32,7 +30,6 @@ def test_days_at_time_open(dates, results):
     assert_series_equal(at_open, pd.Series(
         results, index= pd.DatetimeIndex(results).normalize(), dtype= "datetime64[ns]"
     ).dt.tz_localize(cal.tz).dt.tz_convert("UTC"))
-
 
 @pytest.mark.parametrize("dates, results", [
     (("1952-09-26", "1952-09-30"), ['1952-09-26 15:00:00', '1952-09-29 15:30:00', '1952-09-30 15:30:00']),

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -42,18 +42,12 @@ def test_days_at_time_open(dates, results):
 ])
 def test_days_at_time_close(dates, results):
     cal = NYSEExchangeCalendar()
-    # test market_close before/after 1952-09-29
     valid = cal.valid_days(*dates)
     at_close = cal.days_at_time(valid, "market_close")
 
-    print(at_close)
-    print(pd.Series(
-        results, index= pd.DatetimeIndex(results, freq= None).normalize(), dtype= "datetime64[ns]",
-    ).dt.tz_localize(cal.tz).dt.tz_convert("UTC"))
-
-    assert_series_equal(at_close, pd.Series(
-        results, index= pd.DatetimeIndex(results).normalize(), dtype= "datetime64[ns]"
-    ).dt.tz_localize(cal.tz).dt.tz_convert("UTC"))
+    results = pd.DatetimeIndex(results)
+    ix = pd.DatetimeIndex(results.normalize(), freq= None)
+    assert_series_equal(at_close, pd.Series(results.tz_localize(cal.tz).tz_convert("UTC"), index= ix))
 
 def test_days_at_time_custom():
     cal = NYSEExchangeCalendar()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,17 +86,17 @@ def test_date_range_exceptions():
 
 
 
-
-def test_date_range_permutations():
+@pytest.mark.parametrize("tz", ["America/New_York", "Asia/Ulaanbaatar", "UTC"])
+def test_date_range_permutations(tz):
     # open_time = 9, close_time = 11.30, freq = "1H"
     cal = FakeCalendar(open_time= datetime.time(9), close_time= datetime.time(11, 30))
-    schedule = cal.schedule("2021-01-05", "2021-01-05")
+    schedule = cal.schedule("2021-01-05", "2021-01-05", tz= tz)
 
     # result         matching values for:   closed force_close
     # 9 10 11        left False/ left None/ both False/ None False
     expected = pd.DatetimeIndex(
         ["2021-01-05 01:00:00+00:00", "2021-01-05 02:00:00+00:00",
-         "2021-01-05 03:00:00+00:00"], tz= "UTC")
+         "2021-01-05 03:00:00+00:00"], tz= tz)
     actual = mcal.date_range(schedule, "1H", closed= "left", force_close= False)
     assert_index_equal(actual, expected)
     actual = mcal.date_range(schedule, "1H", closed= "left", force_close= None)
@@ -109,7 +109,7 @@ def test_date_range_permutations():
     # 9 10 11 11.30  left True/ both True/ None True
     expected = pd.DatetimeIndex(
         ["2021-01-05 01:00:00+00:00", "2021-01-05 02:00:00+00:00",
-         "2021-01-05 03:00:00+00:00", "2021-01-05 03:30:00+00:00"], tz= "UTC")
+         "2021-01-05 03:00:00+00:00", "2021-01-05 03:30:00+00:00"], tz= tz)
     actual = mcal.date_range(schedule, "1H", closed= "left", force_close= True)
     assert_index_equal(actual, expected)
     actual = mcal.date_range(schedule, "1H", closed= "both", force_close= True)
@@ -119,28 +119,28 @@ def test_date_range_permutations():
 
     # 10 11          right False
     expected = pd.DatetimeIndex(
-        ["2021-01-05 02:00:00+00:00", "2021-01-05 03:00:00+00:00"], tz="UTC")
+        ["2021-01-05 02:00:00+00:00", "2021-01-05 03:00:00+00:00"], tz=tz)
     actual = mcal.date_range(schedule, "1H", closed="right", force_close=False)
     assert_index_equal(actual, expected)
 
     # 10 11 11.30    right True
     expected = pd.DatetimeIndex(
         ["2021-01-05 02:00:00+00:00", "2021-01-05 03:00:00+00:00",
-         "2021-01-05 03:30:00+00:00"], tz="UTC")
+         "2021-01-05 03:30:00+00:00"], tz=tz)
     actual = mcal.date_range(schedule, "1H", closed="right", force_close=True)
     assert_index_equal(actual, expected)
 
     # 10 11 12       right None
     expected = pd.DatetimeIndex(
         ["2021-01-05 02:00:00+00:00", "2021-01-05 03:00:00+00:00",
-         "2021-01-05 04:00:00+00:00"], tz="UTC")
+         "2021-01-05 04:00:00+00:00"], tz=tz)
     actual = mcal.date_range(schedule, "1H", closed="right", force_close=None)
     assert_index_equal(actual, expected)
 
     # 9 10 11 12     both None/ None None
     expected = pd.DatetimeIndex(
         ["2021-01-05 01:00:00+00:00", "2021-01-05 02:00:00+00:00",
-         "2021-01-05 03:00:00+00:00", "2021-01-05 04:00:00+00:00"], tz="UTC")
+         "2021-01-05 03:00:00+00:00", "2021-01-05 04:00:00+00:00"], tz=tz)
     actual = mcal.date_range(schedule, "1H", closed="both", force_close=None)
     assert_index_equal(actual, expected)
     actual = mcal.date_range(schedule, "1H", closed=None, force_close=None)


### PR DESCRIPTION
This PR covers all the proposed changes in #198 (and #209). 

Backwards Incompatible Changes:
  * MarketCalendar.days_at_time now returns a Series instead of a DatetimeIndex,  which is needed for allowing offsets in special times. 

Other Changes:

  * The property `interruptions` is now available to include data on interruptions
  * The property `interruptions_df` provides these interruptions in a concise dataframe
  * MarketCalendar.schedule has an extra kwarg ` interruptions`, which controls whether interruptions are added to the schedule as extra columns
  * open_at_time can handle schedules with breaks and any number of interruptions.
  * there is an additional class member, `open_close_map`, that indicates which market times to consider opens or closes.
  * times in special_* properties can be wrapped in a tuple to include an offset
  * utils.date_range now handles schedules of any timezone

The section 'Inheriting from a MarketCalendar' in the examples notebook is updated, to demonstrate the added functionality. Although, so far this is only an update to the framework, and no data has been added or changed.
