### PR TITLE
Add type hint for get calendar function

### DIFF
--- a/pandas_market_calendars/calendar_registry.py
+++ b/pandas_market_calendars/calendar_registry.py
@@ -28,7 +28,7 @@ from .exchange_calendar_tase import TASEExchangeCalendar
 from .exchange_calendars_mirror import *
 
 
-def get_calendar(name, open_time=None, close_time=None):
+def get_calendar(name, open_time=None, close_time=None) -> MarketCalendar:
     """
     Retrieves an instance of an MarketCalendar whose name is given.
 


### PR DESCRIPTION
Currently, the implicit return type for the `get_calendar` function is `None` while the actual return type of `get_calendar` is `MarketCalendar` due to the inferred `MarketCalendar.factory` function. This pull request adds the correct type hint for the `get_calendar` function.