### PR TITLE
Various fixes to support Pandas 2.1.x where Index.map() no longer pas…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ celerybeat-schedule
 .env
 .venv
 env/
-venv/
+venv*/
 env.bak/
 venv.bak/
 

--- a/pandas_market_calendars/exchange_calendar_cboe.py
+++ b/pandas_market_calendars/exchange_calendar_cboe.py
@@ -16,17 +16,11 @@ def good_friday_unless_christmas_nye_friday(dt):
     Good Friday is a valid trading day if Christmas Day or New Years Day fall
     on a Friday.
     """
-    year_str = str(dt.year)
-    christmas_weekday = Christmas.observance(
-        pd.Timestamp(year_str+"-12-25")
-    ).weekday()
-    nyd_weekday = USNewYearsDay.observance(
-        pd.Timestamp(year_str+"-01-01")
-    ).weekday()
+    year = dt.year
+    christmas_weekday = Christmas.observance(pd.Timestamp(year=year, month=12, day=25)).weekday()
+    nyd_weekday = USNewYearsDay.observance(pd.Timestamp(year=year, month=1, day=1)).weekday()
     if christmas_weekday != 4 and nyd_weekday != 4:
-        return GoodFriday._apply_rule(
-            pd.Timestamp(str(dt.year)+"-"+str(dt.month)+"-"+str(dt.day))
-        )
+        return GoodFriday.dates(pd.Timestamp(year=year, month=1, day=1), pd.Timestamp(year=year, month=12, day=31))[0]
     else:
         # compatibility for pandas 0.18.1
         return pd.NaT

--- a/pandas_market_calendars/holidays_nyse.py
+++ b/pandas_market_calendars/holidays_nyse.py
@@ -1,3 +1,4 @@
+import pandas as pd
 from dateutil.relativedelta import (MO, TH, TU)
 from pandas import (DateOffset, Timestamp, date_range)
 from datetime import  timedelta
@@ -302,9 +303,6 @@ MonTuesThursBeforeIndependenceDay = Holiday(
     start_date=Timestamp("1995-01-01"),
 )
 
-def july_5th_holiday_observance(datetime_index):
-    return datetime_index[datetime_index.year < 2013]
-
 FridayAfterIndependenceDayNYSEpre2013 = Holiday(
     # When July 4th is a Thursday, the next day is a half day prior to 2013.
     # Since 2013 the early close is on Wednesday and Friday is a full day
@@ -312,8 +310,8 @@ FridayAfterIndependenceDayNYSEpre2013 = Holiday(
     month=7,
     day=5,
     days_of_week=(FRIDAY,),
-    observance=july_5th_holiday_observance,
     start_date=Timestamp("1996-01-01"),
+    end_date=Timestamp("2012-12-31"),
 )
 
 WednesdayBeforeIndependenceDayPost2013 = Holiday(

--- a/pandas_market_calendars/holidays_us.py
+++ b/pandas_market_calendars/holidays_us.py
@@ -10,10 +10,6 @@ from pandas_market_calendars.market_calendar import (FRIDAY, MONDAY, THURSDAY, T
 # NYSE closed at 2:00 PM on Christmas Eve until 1993.
 
 
-def july_5th_holiday_observance(datetime_index):
-    return datetime_index[datetime_index.year < 2013]
-
-
 def following_tuesday_every_four_years_observance(dt):
     return dt + DateOffset(years=(4 - (dt.year % 4)) % 4, weekday=TU(1))
 
@@ -201,8 +197,8 @@ FridayAfterIndependenceDayPre2013 = Holiday(
     month=7,
     day=5,
     days_of_week=(FRIDAY,),
-    observance=july_5th_holiday_observance,
     start_date=Timestamp("1995-01-01"),
+    end_date=Timestamp("2012-12-31"),
 )
 WednesdayBeforeIndependenceDayPost2013 = Holiday(
     # When July 4th is a Thursday, the next day is a half day prior to 2013.

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -544,10 +544,13 @@ def test_schedule():
     assert_series_equal(results.iloc[-1], expected)
 
     # one day schedule
-    expected = pd.DataFrame({'market_open': pd.Timestamp('2016-12-01 03:13:00+0000', tz='UTC'),
-                             'market_close': pd.Timestamp('2016-12-01 03:49:00+0000', tz='UTC')},
-                            index=pd.DatetimeIndex([pd.Timestamp('2016-12-01')], freq='C'),
-                            columns=['market_open', 'market_close'])
+    expected = pd.DataFrame(
+        {'market_open': pd.Timestamp('2016-12-01 03:13:00+0000', tz='UTC'),
+         'market_close': pd.Timestamp('2016-12-01 03:49:00+0000', tz='UTC')},
+        index=pd.DatetimeIndex([pd.Timestamp('2016-12-01')], freq='C'),
+        columns=['market_open', 'market_close'],
+        dtype="datetime64[ns, UTC]"
+    )
     actual = cal.schedule('2016-12-01', '2016-12-01')
     if pd.__version__ < '1.1.0':
         assert_frame_equal(actual, expected)
@@ -557,12 +560,15 @@ def test_schedule():
     # start date after end date
     with pytest.raises(ValueError):
         cal.schedule('2016-02-02', '2016-01-01')
-    
+
     # using a different time zone
-    expected = pd.DataFrame({'market_open': pd.Timestamp('2016-11-30 22:13:00-05:00', tz='US/Eastern'),
-                             'market_close': pd.Timestamp('2016-11-30 22:49:00-05:00', tz='US/Eastern')},
-                            index=pd.DatetimeIndex([pd.Timestamp('2016-12-01')]),
-                            columns=['market_open', 'market_close'])
+    expected = pd.DataFrame(
+        {'market_open': pd.Timestamp('2016-11-30 22:13:00-05:00', tz='US/Eastern'),
+         'market_close': pd.Timestamp('2016-11-30 22:49:00-05:00', tz='US/Eastern')},
+        index=pd.DatetimeIndex([pd.Timestamp('2016-12-01')]),
+        columns=['market_open', 'market_close'],
+        dtype="datetime64[ns, US/Eastern]"
+    )
 
     actual = cal.schedule('2016-12-01', '2016-12-01', tz='US/Eastern')
     if pd.__version__ < '1.1.0':
@@ -704,12 +710,15 @@ def test_schedule_w_breaks():
     assert_series_equal(results.iloc[-1], expected)
 
     # using a different time zone
-    expected = pd.DataFrame({'market_open': pd.Timestamp('2016-12-28 09:30:00-05:00', tz='America/New_York'),
-                             'market_close': pd.Timestamp('2016-12-28 12:00:00-05:00', tz='America/New_York'),
-                             'break_start': pd.Timestamp('2016-12-28 10:00:00-05:00', tz='America/New_York'),
-                             'break_end': pd.Timestamp('2016-12-28 11:00:00-05:00', tz='America/New_York')},
-                            index=pd.DatetimeIndex([pd.Timestamp('2016-12-28')]),
-                            columns=['market_open', 'break_start', 'break_end', 'market_close'])
+    expected = pd.DataFrame(
+        {'market_open': pd.Timestamp('2016-12-28 09:30:00-05:00', tz='America/New_York'),
+         'market_close': pd.Timestamp('2016-12-28 12:00:00-05:00', tz='America/New_York'),
+         'break_start': pd.Timestamp('2016-12-28 10:00:00-05:00', tz='America/New_York'),
+         'break_end': pd.Timestamp('2016-12-28 11:00:00-05:00', tz='America/New_York')},
+        index=pd.DatetimeIndex([pd.Timestamp('2016-12-28')]),
+        columns=['market_open', 'break_start', 'break_end', 'market_close'],
+        dtype="datetime64[ns, America/New_York]"
+    )
 
     actual = cal.schedule('2016-12-28', '2016-12-28', tz='America/New_York')
     if pd.__version__ < '1.1.0':

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -347,7 +347,7 @@ def test_all_full_day_holidays_since_1928(request):
     assert_index_equal(expected, actual)
 
     # using the holidays method
-    actual = pd.DatetimeIndex(nyse.holidays().holidays).unique()
+    actual = pd.DatetimeIndex(nyse.holidays().holidays, dtype='datetime64[ns]').unique()
     slice_locs = actual.slice_locs(expected[0], expected[-1])
     actual = actual[slice_locs[0]:slice_locs[1]]
     assert_index_equal(expected, actual)


### PR DESCRIPTION
Various fixes to support Pandas 2.1.x where Index.map() no longer passes through the index, it only passes through the elements of the index, and date time parsing is more eager to use second-level granularity rather than ns level.

#279 