### PR TITLE
Add IEX To calendars documentation

### DIFF
--- a/docs/calendars.rst
+++ b/docs/calendars.rst
@@ -22,6 +22,7 @@ Exchange  TASE   TASEExchangeCalendar               gabglus
 Exchange  HKEX   HKEXExchangeCalendar    Yes        1dot75cm
 Exchange  ASX    ASXExchangeCalendar                pulledlamb
 Exchange  BSE    BSEExchangeCalendar                rakesh1988
+Exchange  IEX    IEXExchangeCalendar     Yes        carterjfulcher
 ========= ====== ===================== ============ ==========
 
 Futures Calendars


### PR DESCRIPTION
I added IEX a few months ago and forgot to add it to docs