### PR TITLE
Fix CME_Agriculture name in docs

### DIFF
--- a/docs/calendars.rst
+++ b/docs/calendars.rst
@@ -32,7 +32,7 @@ Futures Calendars
 ========== ================= =================================== ============ ============
 CME        CME_Equity         CMEEquityExchangeCalendar           Yes         rsheftel
 CME        CME_Bond           CMEBondExchangeCalendar             Yes         rsheftel
-CME        CME_Agricultural   CMEAgriculturalExchangeCalendar     Yes         lionelyoung
+CME        CME_Agriculture   CMEAgriculturalExchangeCalendar     Yes         lionelyoung
 CME        CME Globex Crypto  CMEGlobexCryptoExchangeCalendar     Yes         Coinbase Asset Management
 ========== ================= =================================== ============ ============
 


### PR DESCRIPTION
calendar is called CME_Agriculture not CME_Agricultural, per https://github.com/rsheftel/pandas_market_calendars/blob/3a43b5b91f2ef82b9db70038179728806508f29c/pandas_market_calendars/calendars/cme.py#L126