### PR TITLE
Added BMF calendar holiday for New Year's Eve on Sunday

### DIFF
--- a/pandas_market_calendars/calendars/bmf.py
+++ b/pandas_market_calendars/calendars/bmf.py
@@ -122,6 +122,13 @@ AnoNovoSabado = Holiday(
     day=30,
     days_of_week=(FRIDAY,),
 )
+# New Year's Eve falls on Sunday
+AnoNovoDomingo = Holiday(
+    "Ano Novo Domingo",
+    month=12,
+    day=29,
+    days_of_week=(FRIDAY,),
+)
 
 ##########################
 # Non-recurring holidays
@@ -154,7 +161,7 @@ class BMFExchangeCalendar(MarketCalendar):
     - Proclamation of the Republic (November 15)
     - Day of Black Awareness (November 20 after 2004 until 2021, skipping 2020)
     - Christmas (December 24 and 25)
-    - Day before New Year's Eve (December 30 if NYE falls on a Saturday)
+    - Friday before New Year's Eve (December 30 or 29 if NYE falls on a Saturday or Sunday, respectively)
     - New Year's Eve (December 31)
     """
 
@@ -194,6 +201,7 @@ class BMFExchangeCalendar(MarketCalendar):
                 Natal,
                 AnoNovo,
                 AnoNovoSabado,
+                AnoNovoDomingo,
             ]
         )
 

--- a/tests/test_bmf_calendar.py
+++ b/tests/test_bmf_calendar.py
@@ -37,3 +37,17 @@ def test_post_2022_regulation_change():
                     pd.Timestamp(datetime.date(year, month, day), tz="UTC").to_datetime64()
                     not in holidays
             )
+
+
+def test_sunday_new_years_eve():
+    # All instances of December 29th on a Friday should be holidays
+    holidays = BMFExchangeCalendar().holidays().holidays
+
+    for year in range(1994, 2040):
+        date = pd.Timestamp(datetime.date(year, 12, 29), tz="UTC")
+        if date.day_of_week == 4:
+            # December 29th on a Friday
+            assert (
+                    date.to_datetime64()
+                    not in holidays
+            )


### PR DESCRIPTION
Added holiday to BMF calendar for when New Year's Eve falls on Sunday. Previous holiday occurrences can be seen in 1995, 2000, 2006, 2017 and 2023 (ticker BMFBOVESPA:IBOV on TradingView is the main stock index).