### PR TITLE
Added national holiday for BMF calendar (Black Awareness Day, Nov 20th)

### DIFF
--- a/pandas_market_calendars/calendars/bmf.py
+++ b/pandas_market_calendars/calendars/bmf.py
@@ -89,13 +89,20 @@ ProclamacaoRepublica = Holiday(
     month=11,
     day=15,
 )
-# Day of Black Awareness
+# Day of Black Awareness (municipal holiday for the city of São Paulo)
 ConscienciaNegra = Holiday(
     "Dia da Consciencia Negra",
     month=11,
     day=20,
     start_date="2004-01-01",
     end_date="2019-12-31",
+)
+# Day of Black Awareness (national holiday)
+ConscienciaNegraNacional = Holiday(
+    "Dia da Consciencia Negra",
+    month=11,
+    day=20,
+    start_date="2023-12-22",
 )
 # Christmas Eve
 VesperaNatal = Holiday(
@@ -154,12 +161,13 @@ class BMFExchangeCalendar(MarketCalendar):
     - Corpus Christi (60 days after Easter)
     - Tiradentes (April 21)
     - Labor day (May 1)
-    - Constitutionalist Revolution (July 9 after 1997 until 2021, skipping 2020)
+    - Constitutionalist Revolution (July 9 from 1997 until 2021, skipping 2020)
     - Independence Day (September 7)
     - Our Lady of Aparecida Feast (October 12)
     - All Souls' Day (November 2)
     - Proclamation of the Republic (November 15)
-    - Day of Black Awareness (November 20 after 2004 until 2021, skipping 2020)
+    - Day of Black Awareness, municipal holiday for the city of São Paulo (November 20 from 2004 until 2021, skipping 2020)
+    - Day of Black Awareness, national holiday (November 20 starting in 2024)
     - Christmas (December 24 and 25)
     - Friday before New Year's Eve (December 30 or 29 if NYE falls on a Saturday or Sunday, respectively)
     - New Year's Eve (December 31)
@@ -197,6 +205,7 @@ class BMFExchangeCalendar(MarketCalendar):
                 Finados,
                 ProclamacaoRepublica,
                 ConscienciaNegra,
+                ConscienciaNegraNacional,
                 VesperaNatal,
                 Natal,
                 AnoNovo,

--- a/tests/test_bmf_calendar.py
+++ b/tests/test_bmf_calendar.py
@@ -57,7 +57,7 @@ def test_sunday_new_years_eve():
         if date.day_of_week == 4:
             # December 29th on a Friday
 
-            assert date.to_datetime64() not in holidays
+            assert date.to_datetime64() in holidays
 
 
 def test_post_2022_nov20():
@@ -68,5 +68,5 @@ def test_post_2022_nov20():
     for year in range(2024, 2040):
         assert (
             pd.Timestamp(datetime.date(year, 11, 20), tz="UTC").to_datetime64()
-            not in holidays
+            in holidays
         )

--- a/tests/test_bmf_calendar.py
+++ b/tests/test_bmf_calendar.py
@@ -48,3 +48,18 @@ def test_sunday_new_years_eve():
         if date.day_of_week == 4:
             # December 29th on a Friday
             assert date.to_datetime64() not in holidays
+
+
+
+def test_post_2022_nov20():
+    # November 20th municipal holiday should be missing in 2022 and 2023 (ended in 2021)
+    # November 20th national holiday should be present from 2024
+    holidays = BMFExchangeCalendar().holidays().holidays
+
+    for date in ["2022-11-20", "2023-11-20"]:
+        assert pd.Timestamp(date, tz="UTC").to_datetime64() not in holidays
+
+    for year in range(2024, 2040):
+        assert (
+            pd.Timestamp(datetime.date(year, 11, 20), tz="UTC").to_datetime64() not in holidays
+        )

--- a/tests/test_bmf_calendar.py
+++ b/tests/test_bmf_calendar.py
@@ -13,6 +13,7 @@ def test_time_zone():
 def test_2020_holidays_skip():
     # 2020-07-09 - skipped due to covid
     # 2020-11-20 - skipped due to covid
+
     holidays = BMFExchangeCalendar().holidays().holidays
     for date in ["2019-07-09", "2019-11-20", "2021-07-09", "2021-11-20"]:
         assert pd.Timestamp(date, tz="UTC").to_datetime64() in holidays
@@ -23,6 +24,7 @@ def test_2020_holidays_skip():
 def test_post_2022_regulation_change():
     # Regional holidays no longer observed: January 25th, July 9th, November 20th
     # November 20th was reinstated as a national holiday starting in 2024
+
     holidays = BMFExchangeCalendar().holidays().holidays
 
     for year in [2017, 2018, 2019, 2021]:  # skip 2020 due to test above
@@ -31,14 +33,12 @@ def test_post_2022_regulation_change():
                 pd.Timestamp(datetime.date(year, month, day), tz="UTC").to_datetime64()
                 in holidays
             )
-
     for year in range(2022, 2040):
         for month, day in [(1, 25), (7, 9)]:
             assert (
                 pd.Timestamp(datetime.date(year, month, day), tz="UTC").to_datetime64()
                 not in holidays
             )
-
     for year in range(2022, 2024):
         for month, day in [(11, 20)]:
             assert (
@@ -49,21 +49,24 @@ def test_post_2022_regulation_change():
 
 def test_sunday_new_years_eve():
     # All instances of December 29th on a Friday should be holidays
+
     holidays = BMFExchangeCalendar().holidays().holidays
 
     for year in range(1994, 2040):
         date = pd.Timestamp(datetime.date(year, 12, 29), tz="UTC")
         if date.day_of_week == 4:
             # December 29th on a Friday
-            assert date.to_datetime64() not in holidays
 
+            assert date.to_datetime64() not in holidays
 
 
 def test_post_2022_nov20():
     # November 20th national holiday should be present from 2024
+
     holidays = BMFExchangeCalendar().holidays().holidays
 
     for year in range(2024, 2040):
         assert (
-            pd.Timestamp(datetime.date(year, 11, 20), tz="UTC").to_datetime64() not in holidays
+            pd.Timestamp(datetime.date(year, 11, 20), tz="UTC").to_datetime64()
+            not in holidays
         )

--- a/tests/test_bmf_calendar.py
+++ b/tests/test_bmf_calendar.py
@@ -22,6 +22,7 @@ def test_2020_holidays_skip():
 
 def test_post_2022_regulation_change():
     # Regional holidays no longer observed: January 25th, July 9th, November 20th
+    # November 20th was reinstated as a national holiday starting in 2024
     holidays = BMFExchangeCalendar().holidays().holidays
 
     for year in [2017, 2018, 2019, 2021]:  # skip 2020 due to test above
@@ -32,7 +33,14 @@ def test_post_2022_regulation_change():
             )
 
     for year in range(2022, 2040):
-        for month, day in [(1, 25), (7, 9), (11, 20)]:
+        for month, day in [(1, 25), (7, 9)]:
+            assert (
+                pd.Timestamp(datetime.date(year, month, day), tz="UTC").to_datetime64()
+                not in holidays
+            )
+
+    for year in range(2022, 2024):
+        for month, day in [(11, 20)]:
             assert (
                 pd.Timestamp(datetime.date(year, month, day), tz="UTC").to_datetime64()
                 not in holidays
@@ -52,12 +60,8 @@ def test_sunday_new_years_eve():
 
 
 def test_post_2022_nov20():
-    # November 20th municipal holiday should be missing in 2022 and 2023 (ended in 2021)
     # November 20th national holiday should be present from 2024
     holidays = BMFExchangeCalendar().holidays().holidays
-
-    for date in ["2022-11-20", "2023-11-20"]:
-        assert pd.Timestamp(date, tz="UTC").to_datetime64() not in holidays
 
     for year in range(2024, 2040):
         assert (


### PR DESCRIPTION
Added new national holiday (Black Awareness Day) on November 20th starting in 2024. The same date was a municipal holiday until 2021.

The new holiday is officially added through "Circular Letter 215/2023", published on 2023-12-22 and available [here](https://www.b3.com.br/data/files/FE/25/60/54/D339C8103152D4C8AC094EA8/OC%20215-2023%20PRE%20Calendario%20de%20Feriados%202024%20-%20Feriado%2020.11(EN).pdf).

Excerpt:
![image](https://github.com/rsheftel/pandas_market_calendars/assets/10237982/84bc7c77-9892-49ca-a50c-01336fdab4ce)

The latest official BMF calendar can be verified [here](https://www.b3.com.br/en_us/solutions/platforms/puma-trading-system/for-members-and-traders/trading-calendar/holidays/).

I will add new tests next. Because of the old holiday on the same date, the previous test has to be modified with an end date.