### PR TITLE
Fixed 2024 CNY's Eve

### DIFF
--- a/pandas_market_calendars/holidays/cn.py
+++ b/pandas_market_calendars/holidays/cn.py
@@ -565,6 +565,7 @@ all_holidays = [
     Timestamp("2023-10-05"),
     Timestamp("2023-10-06"),
     Timestamp("2024-01-01"),
+    Timestamp("2024-02-09"),
     Timestamp("2024-02-12"),
     Timestamp("2024-02-13"),
     Timestamp("2024-02-14"),


### PR DESCRIPTION
According to government schedule 2024 CNY's Eve is not a public holiday, but the market was not open on that day.