### PR TITLE
Remove German National Day from Eurex holidays

### DIFF
--- a/pandas_market_calendars/calendars/eurex.py
+++ b/pandas_market_calendars/calendars/eurex.py
@@ -43,13 +43,6 @@ MayBank = Holiday(
     day=1,
     days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
 )
-# German National Holiday (Tag der Deutschen Einheit)
-GermanNationalDay = Holiday(
-    "Tag der Deutschen Einheit",
-    month=10,
-    day=3,
-    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
-)
 # Christmas Eve
 ChristmasEve = Holiday(
     "Christmas Eve",
@@ -116,7 +109,6 @@ class EUREXExchangeCalendar(MarketCalendar):
                 GoodFriday,
                 EasterMonday,
                 MayBank,
-                GermanNationalDay,
                 Christmas,
                 WeekendChristmas,
                 BoxingDay,


### PR DESCRIPTION
Remove German National Day from Eurex holidays

In the calendars available in [Eurex Trading calendar archive](https://www.eurex.com/ex-en/trade/trading-calendar/trading-calendar-archive/) (that go back to the year 2000), the German National Day is only a holiday for "German equity and equity index derivatives as well as ETF and ETC derivatives, which are based on Xetra® listing" (starts appearing in 2014). There are years (for instance 2017) for which there are more holidays for Germany. 