### PR TITLE
Update cme.py with Juneteenth holiday

### DIFF
--- a/pandas_market_calendars/calendars/cme.py
+++ b/pandas_market_calendars/calendars/cme.py
@@ -160,6 +160,7 @@ class CMEAgricultureExchangeCalendar(MarketCalendar):
                 USPresidentsDay,
                 GoodFriday,
                 USMemorialDay,
+                USJuneteenthAfter2022,
                 USIndependenceDay,
                 USLaborDay,
                 USThanksgivingDay,


### PR DESCRIPTION
Added "USJuneteenthAfter2022" to the Abstract Holiday Calendar for CME Equities and CME Agriculture as a follow-up to my issue posted here: https://github.com/rsheftel/pandas_market_calendars/issues/335