### PR TITLE
24/7 and XTAE Calendar Fixes

### DIFF
--- a/pandas_market_calendars/calendars/mirror.py
+++ b/pandas_market_calendars/calendars/mirror.py
@@ -98,6 +98,8 @@ class TradingCalendar(MarketCalendar):
         return self._ec.special_closes_adhoc
 
 
+DAYMASKS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
 calendars = exchange_calendars.calendar_utils._default_calendar_factories  # noqa
 
 time_props = dict(
@@ -118,6 +120,19 @@ for exchange in calendars:
             continue
         regular_market_times[new] = times
 
+    weekmask = "Mon Tue Wed Thu Fri"
+
+    if hasattr(cal, "weekmask"):
+        mask_prop = getattr(cal, "weekmask")
+        if isinstance(mask_prop, property) and mask_prop.fget is not None:
+            weekmask = " ".join(
+                [DAYMASKS[i] for i, x in enumerate(mask_prop.fget(cal)) if x == "1"]
+            )
+        elif isinstance(mask_prop, str):
+            weekmask = " ".join(
+                [DAYMASKS[i] for i, x in enumerate(mask_prop) if x == "1"]
+            )
+
     cal = type(
         exchange,
         (TradingCalendar,),
@@ -125,6 +140,7 @@ for exchange in calendars:
             "_ec_class": calendars[exchange],
             "alias": [exchange],
             "regular_market_times": regular_market_times,
+            "weekmask": weekmask,
         },
     )
     locals()[f"{exchange}ExchangeCalendar"] = cal

--- a/tests/test_24_7_calendar.py
+++ b/tests/test_24_7_calendar.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from pandas.testing import assert_index_equal
+
+import pandas_market_calendars as mcal
+
+
+def test_weekends():
+    actual = mcal.get_calendar("24/7").schedule("2012-07-01", "2012-07-10").index
+
+    expected = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2012-07-01"),
+            pd.Timestamp("2012-07-02"),
+            pd.Timestamp("2012-07-03"),
+            pd.Timestamp("2012-07-04"),
+            pd.Timestamp("2012-07-05"),
+            pd.Timestamp("2012-07-06"),
+            pd.Timestamp("2012-07-07"),
+            pd.Timestamp("2012-07-08"),
+            pd.Timestamp("2012-07-09"),
+            pd.Timestamp("2012-07-10"),
+        ]
+    )
+
+    assert_index_equal(actual, expected)

--- a/tests/test_xtae_calendar.py
+++ b/tests/test_xtae_calendar.py
@@ -1,0 +1,53 @@
+import pandas as pd
+from pandas.testing import assert_index_equal, assert_series_equal
+
+import pandas_market_calendars as mcal
+
+
+def test_xtae_schedule():
+    actual = mcal.get_calendar("XTAE").schedule("2012-07-01", "2012-07-10").index
+
+    expected = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2012-07-01"),
+            pd.Timestamp("2012-07-02"),
+            pd.Timestamp("2012-07-03"),
+            pd.Timestamp("2012-07-04"),
+            pd.Timestamp("2012-07-05"),
+            pd.Timestamp("2012-07-08"),
+            pd.Timestamp("2012-07-09"),
+            pd.Timestamp("2012-07-10"),
+        ]
+    )
+
+    assert_index_equal(actual, expected)
+
+
+def test_xtae_sunday_close():
+    actual = mcal.get_calendar("XTAE").schedule("2012-07-01", "2012-07-10")
+
+    expected = pd.Series(
+        index=[
+            pd.Timestamp("2012-07-01"),
+            pd.Timestamp("2012-07-02"),
+            pd.Timestamp("2012-07-03"),
+            pd.Timestamp("2012-07-04"),
+            pd.Timestamp("2012-07-05"),
+            pd.Timestamp("2012-07-08"),
+            pd.Timestamp("2012-07-09"),
+            pd.Timestamp("2012-07-10"),
+        ],
+        data=[
+            pd.Timestamp("2012-07-01 12:40:00+00:00"),
+            pd.Timestamp("2012-07-02 14:15:00+00:00"),
+            pd.Timestamp("2012-07-03 14:15:00+00:00"),
+            pd.Timestamp("2012-07-04 14:15:00+00:00"),
+            pd.Timestamp("2012-07-05 14:15:00+00:00"),
+            pd.Timestamp("2012-07-08 12:40:00+00:00"),
+            pd.Timestamp("2012-07-09 14:15:00+00:00"),
+            pd.Timestamp("2012-07-10 14:15:00+00:00"),
+        ],
+        name="market_close",
+    )
+
+    assert_series_equal(actual["market_close"], expected)


### PR DESCRIPTION
Pull Request addresses Issues #345 and #276. 

Issue #345 stemmed from Exchange_Calendar weekmasks not being transferred from the exchange_calendar parent class into the Mirrored TradingCalendar Class. The added function ( linked below ) preserves weekmask's day abbreviation convention even though this isn't strictly necessary. 

https://github.com/jack-of-some-trades/pandas_market_calendars/blob/e4afd4fae0efa35c7f3340af2478e3f0a46675ad/pandas_market_calendars/calendars/mirror.py#L103C10-L117C9 

Issue #276 stemmed from the  "XTAE" exchange_calendar handling the unique sunday close time using the 'special_closes' property. To compensate for this MarketCalendar._special_dates() can now parse a tuple of (time_=time, calendar=int) where the calendar can be an int [0,6] which represents the day of the week to repeat. (Changes linked below)

https://github.com/jack-of-some-trades/pandas_market_calendars/blob/e4afd4fae0efa35c7f3340af2478e3f0a46675ad/pandas_market_calendars/market_calendar.py#L641-L652