### PR TITLE
Update market close of JPX to 15:30

### DIFF
--- a/pandas_market_calendars/calendars/jpx.py
+++ b/pandas_market_calendars/calendars/jpx.py
@@ -21,13 +21,17 @@ class JPXExchangeCalendar(MarketCalendar):
 
     Open Time: 9:31 AM, Asia/Tokyo
     LUNCH BREAK :facepalm: : 11:30 AM - 12:30 PM Asia/Tokyo
-    Close Time: 4:00 PM, Asia/Tokyo
+    Close Time: 3:30 PM, Asia/Tokyo
+
+    Market close of Japan changed from 3:00 PM to 3:30 PM on November 5, 2024
+    Reference:
+    https://www.jpx.co.jp/english/equities/trading/domestic/tvdivq0000006blj-att/tradinghours_eg.pdf
     """
 
     aliases = ["JPX", "XJPX"]
     regular_market_times = {
         "market_open": ((None, time(9)),),
-        "market_close": ((None, time(15)),),
+        "market_close": ((None, time(15)), ("2024-11-05", time(15, 30))),
         "break_start": ((None, time(11, 30)),),
         "break_end": ((None, time(12, 30)),),
     }

--- a/tests/test_jpx_calendar.py
+++ b/tests/test_jpx_calendar.py
@@ -267,3 +267,37 @@ def test_jpx_trading_days_since_1949(request):
     actual = pd.date_range(start_date, end_date, freq=day_generator)
 
     assert_index_equal(expected, actual)
+
+
+def test_jpx_change_in_market_close():
+    """
+    The market close of Japan changed from 3:00 PM to 3:30 PM on November 5, 2024, make sure the
+    calendar reflects this change.
+    """
+    jpx_calendar = JPXExchangeCalendar()
+    jpx_schedule = jpx_calendar.schedule(start_date="2024-10-28", end_date="2024-11-08")
+
+    business_dates_before_change = [
+        "2024-10-28",
+        "2024-10-29",
+        "2024-10-30",
+        "2024-10-31",
+        "2024-11-01",
+    ]
+
+    business_dates_after_change = [
+        "2024-11-05",
+        "2024-11-06",
+        "2024-11-07",
+        "2024-11-08",
+    ]
+
+    for date in business_dates_before_change:
+        assert jpx_schedule.loc[date, "market_close"] == pd.Timestamp(
+            f"{date} 15:00", tz="Asia/Tokyo"
+        )
+
+    for date in business_dates_after_change:
+        assert jpx_schedule.loc[date, "market_close"] == pd.Timestamp(
+            f"{date} 15:30", tz="Asia/Tokyo"
+        )


### PR DESCRIPTION
Pull Request addresses Issue #350.

Issue #350 stems from the JPX market closing time, which has been extended to 15:30 (local time) starting from 2024-11-05. The current implementation does not reflect this change, resulting in an incorrect closing time of 15:00 (local time).

This update modifies the market closing time in the `JPXExchangeCalendar` class to reflect the new closing time.