### PR TITLE
Jimmy carter

### DIFF
--- a/pandas_market_calendars/calendars/nyse.py
+++ b/pandas_market_calendars/calendars/nyse.py
@@ -297,6 +297,8 @@ from pandas_market_calendars.holidays.nyse import (
     HurricaneSandyClosings2012,
     # 2018
     GeorgeHWBushDeath2018,
+    # 2025
+    JimmyCarterDeath2025,
 )
 from pandas_market_calendars.market_calendar import MarketCalendar
 
@@ -961,6 +963,7 @@ class NYSEExchangeCalendar(MarketCalendar):
                 September11Closings2001,
                 HurricaneSandyClosings2012,
                 GeorgeHWBushDeath2018,
+                JimmyCarterDeath2025,
             )
         )
 

--- a/pandas_market_calendars/holidays/nyse.py
+++ b/pandas_market_calendars/holidays/nyse.py
@@ -1529,3 +1529,8 @@ HurricaneSandyClosings2012 = [
 GeorgeHWBushDeath2018 = [
     Timestamp("2018-12-05", tz="UTC"),
 ]
+
+# 2025
+JimmyCarterDeath2025 = [
+    Timestamp("2025-01-09", tz="UTC"),
+]


### PR DESCRIPTION
https://www.bloomberg.com/news/articles/2024-12-30/us-stock-market-to-close-jan-9-on-day-of-mourning-for-carter