### PR TITLE
Additional Features

### DIFF
--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -5,6 +5,13 @@ Updates
 -------
 4.6.0 (XX/XX/2025)
 ~~~~~~~~~~~~~~~~~~
+- Updated useage.ipynb with information on added features
+- Added mark_session() Util Function
+- Added MarketCalendar.date_range_htf() Method
+- Added MarketCalendar.schedule_from_days() Method
+- Split NYSE Holiday Calendar into Two Calendars to support Date_Range_HTF()
+  - NYSE.weekmask now returns "Mon Tue Wed Thur Fri" instead of "Mon Tue Wed Thur Fri Sat"
+- Start, End, Periods, and Session Arguments added to Date_Range() from PR #358
 - Speed enhancements from PR #358
 
 4.5.1 (01/01/2025)

--- a/examples/usage.ipynb
+++ b/examples/usage.ipynb
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [
     {
@@ -140,7 +140,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exchange open valid business days"
+    "### Exchange open valid business days: Valid_Days()"
    ]
   },
   {
@@ -166,10 +166,10 @@
        "               '2017-01-03 00:00:00+00:00', '2017-01-04 00:00:00+00:00',\n",
        "               '2017-01-05 00:00:00+00:00', '2017-01-06 00:00:00+00:00',\n",
        "               '2017-01-09 00:00:00+00:00', '2017-01-10 00:00:00+00:00'],\n",
-       "              dtype='datetime64[ns, UTC]', freq=None)"
+       "              dtype='datetime64[ns, UTC]', freq='C')"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,12 +182,224 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exchange open valid business days: Date_Range_HTF()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2016-12-20', '2016-12-21', '2016-12-22', '2016-12-23',\n",
+       "               '2016-12-27', '2016-12-28', '2016-12-29', '2016-12-30',\n",
+       "               '2017-01-03', '2017-01-04', '2017-01-05', '2017-01-06',\n",
+       "               '2017-01-09', '2017-01-10'],\n",
+       "              dtype='datetime64[ns]', freq='C')"
+      ]
+     },
+     "execution_count": 107,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# date_range_htf() is functionally identical to valid_days() when given a frequency of '1D', a Start, and End Date\n",
+    "nyse.date_range_htf('1D', start='2016-12-20', end='2017-01-10')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2017-01-03', '2017-01-04', '2017-01-05', '2017-01-06'], dtype='datetime64[ns]', freq='C')"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# However, it can be used in a similar manner to pandas.date_range()\n",
+    "# Request a number of open days from a given start date\n",
+    "nyse.date_range_htf('1D', start='2017-01-01', periods=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2016-12-30', '2017-01-03', '2017-01-04', '2017-01-05'], dtype='datetime64[ns]', freq='C')"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Request a number of open days prior to a given end date\n",
+    "nyse.date_range_htf('1D', end='2017-01-05', periods=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2016-12-20', '2016-12-22', '2016-12-27', '2016-12-29',\n",
+       "               '2017-01-03', '2017-01-05', '2017-01-09'],\n",
+       "              dtype='datetime64[ns]', freq=None)"
+      ]
+     },
+     "execution_count": 110,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Request every other open business day in the given range\n",
+    "nyse.date_range_htf('2D', start='2016-12-20', end='2017-01-10')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2016-12-23', '2016-12-30', '2017-01-06'], dtype='datetime64[ns]', freq=None)"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The Last Trading Day of every Week in the range\n",
+    "nyse.date_range_htf('1W', start='2016-12-20', end='2017-01-10')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2016-12-27', '2017-01-03', '2017-01-09'], dtype='datetime64[ns]', freq=None)"
+      ]
+     },
+     "execution_count": 112,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The First Trading Day of every Week in the range\n",
+    "nyse.date_range_htf('1W', start='2016-12-20', end='2017-01-10', closed='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2017-01-03', '2017-02-01', '2017-03-01', '2017-04-03',\n",
+       "               '2017-05-01', '2017-06-01', '2017-07-03', '2017-08-01',\n",
+       "               '2017-09-01', '2017-10-02', '2017-11-01', '2017-12-01'],\n",
+       "              dtype='datetime64[ns]', freq=None)"
+      ]
+     },
+     "execution_count": 113,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The First Trading Day of every Month in the range\n",
+    "nyse.date_range_htf('1M', start='2017-01-01', end='2018-01-01', closed='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2017-01-03', '2017-10-02', '2018-07-02', '2019-04-01',\n",
+       "               '2020-01-02', '2020-10-01', '2021-07-01', '2022-04-01',\n",
+       "               '2023-01-03', '2023-10-02', '2024-07-01'],\n",
+       "              dtype='datetime64[ns]', freq=None)"
+      ]
+     },
+     "execution_count": 114,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The First Trading Day of every Third Quarter in the range\n",
+    "nyse.date_range_htf('3Q', start='2017-01-01', end='2025-01-01', closed='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 115,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2017-07-03', '2018-07-02', '2019-07-01', '2020-07-01',\n",
+       "               '2021-07-01', '2022-07-01', '2023-07-03', '2024-07-01',\n",
+       "               '2025-07-01', '2026-07-01'],\n",
+       "              dtype='datetime64[ns]', freq=None)"
+      ]
+     },
+     "execution_count": 115,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The First Trading Day of the next 10 Fiscal Years\n",
+    "nyse.date_range_htf('Y', start='2017-01-01', periods=10, closed='left', month_anchor='JUL')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Schedule"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
@@ -278,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
@@ -351,7 +563,7 @@
        "2012-07-10 2012-07-10 13:30:00+00:00 2012-07-10 20:00:00+00:00"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -364,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
@@ -459,7 +671,7 @@
        "2012-07-10 2012-07-10 20:00:00+00:00 2012-07-11 00:00:00+00:00  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -472,7 +684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 119,
    "metadata": {
     "scrolled": true
    },
@@ -547,7 +759,7 @@
        "2012-07-10 2012-07-11 00:00:00+00:00 2012-07-10 13:30:00+00:00"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -564,12 +776,313 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Schedule_from_days\n",
+    "*CAVEAT: This function assumes all the days passed to it are valid trading days. If random dates are passed, it will not be filtered down to only valid trading days."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>market_close</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2016-12-30</th>\n",
+       "      <td>2016-12-30 14:30:00+00:00</td>\n",
+       "      <td>2016-12-30 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-01-03</th>\n",
+       "      <td>2017-01-03 14:30:00+00:00</td>\n",
+       "      <td>2017-01-03 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-01-04</th>\n",
+       "      <td>2017-01-04 14:30:00+00:00</td>\n",
+       "      <td>2017-01-04 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-01-05</th>\n",
+       "      <td>2017-01-05 14:30:00+00:00</td>\n",
+       "      <td>2017-01-05 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-01-06</th>\n",
+       "      <td>2017-01-06 14:30:00+00:00</td>\n",
+       "      <td>2017-01-06 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-01-09</th>\n",
+       "      <td>2017-01-09 14:30:00+00:00</td>\n",
+       "      <td>2017-01-09 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-01-10</th>\n",
+       "      <td>2017-01-10 14:30:00+00:00</td>\n",
+       "      <td>2017-01-10 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         market_open              market_close\n",
+       "2016-12-30 2016-12-30 14:30:00+00:00 2016-12-30 21:00:00+00:00\n",
+       "2017-01-03 2017-01-03 14:30:00+00:00 2017-01-03 21:00:00+00:00\n",
+       "2017-01-04 2017-01-04 14:30:00+00:00 2017-01-04 21:00:00+00:00\n",
+       "2017-01-05 2017-01-05 14:30:00+00:00 2017-01-05 21:00:00+00:00\n",
+       "2017-01-06 2017-01-06 14:30:00+00:00 2017-01-06 21:00:00+00:00\n",
+       "2017-01-09 2017-01-09 14:30:00+00:00 2017-01-09 21:00:00+00:00\n",
+       "2017-01-10 2017-01-10 14:30:00+00:00 2017-01-10 21:00:00+00:00"
+      ]
+     },
+     "execution_count": 120,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This is Equivalent to calling nyse.schedule('2016-12-30', '2017-01-10')\n",
+    "dates = nyse.date_range_htf('1D', start='2016-12-30', end='2017-01-10')\n",
+    "nyse.schedule_from_days(dates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>market_close</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2017-03-31</th>\n",
+       "      <td>2017-03-31 13:30:00+00:00</td>\n",
+       "      <td>2017-03-31 20:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-06-30</th>\n",
+       "      <td>2017-06-30 13:30:00+00:00</td>\n",
+       "      <td>2017-06-30 20:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-09-29</th>\n",
+       "      <td>2017-09-29 13:30:00+00:00</td>\n",
+       "      <td>2017-09-29 20:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-12-29</th>\n",
+       "      <td>2017-12-29 14:30:00+00:00</td>\n",
+       "      <td>2017-12-29 21:00:00+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         market_open              market_close\n",
+       "2017-03-31 2017-03-31 13:30:00+00:00 2017-03-31 20:00:00+00:00\n",
+       "2017-06-30 2017-06-30 13:30:00+00:00 2017-06-30 20:00:00+00:00\n",
+       "2017-09-29 2017-09-29 13:30:00+00:00 2017-09-29 20:00:00+00:00\n",
+       "2017-12-29 2017-12-29 14:30:00+00:00 2017-12-29 21:00:00+00:00"
+      ]
+     },
+     "execution_count": 121,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# But This method can produce a schedule from any range produced by date_range_htf()\n",
+    "dates = nyse.date_range_htf('Q', start='2017-01-01', end='2018-01-10')\n",
+    "nyse.schedule_from_days(dates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pre</th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>market_close</th>\n",
+       "      <th>post</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2017-01-03</th>\n",
+       "      <td>2017-01-03 04:00:00-05:00</td>\n",
+       "      <td>2017-01-03 09:30:00-05:00</td>\n",
+       "      <td>2017-01-03 16:00:00-05:00</td>\n",
+       "      <td>2017-01-03 20:00:00-05:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-03-31</th>\n",
+       "      <td>2017-03-31 04:00:00-04:00</td>\n",
+       "      <td>2017-03-31 09:30:00-04:00</td>\n",
+       "      <td>2017-03-31 16:00:00-04:00</td>\n",
+       "      <td>2017-03-31 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-04-03</th>\n",
+       "      <td>2017-04-03 04:00:00-04:00</td>\n",
+       "      <td>2017-04-03 09:30:00-04:00</td>\n",
+       "      <td>2017-04-03 16:00:00-04:00</td>\n",
+       "      <td>2017-04-03 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-06-30</th>\n",
+       "      <td>2017-06-30 04:00:00-04:00</td>\n",
+       "      <td>2017-06-30 09:30:00-04:00</td>\n",
+       "      <td>2017-06-30 16:00:00-04:00</td>\n",
+       "      <td>2017-06-30 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-07-03</th>\n",
+       "      <td>2017-07-03 04:00:00-04:00</td>\n",
+       "      <td>2017-07-03 09:30:00-04:00</td>\n",
+       "      <td>2017-07-03 13:00:00-04:00</td>\n",
+       "      <td>2017-07-03 13:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-09-29</th>\n",
+       "      <td>2017-09-29 04:00:00-04:00</td>\n",
+       "      <td>2017-09-29 09:30:00-04:00</td>\n",
+       "      <td>2017-09-29 16:00:00-04:00</td>\n",
+       "      <td>2017-09-29 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-10-02</th>\n",
+       "      <td>2017-10-02 04:00:00-04:00</td>\n",
+       "      <td>2017-10-02 09:30:00-04:00</td>\n",
+       "      <td>2017-10-02 16:00:00-04:00</td>\n",
+       "      <td>2017-10-02 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2017-12-29</th>\n",
+       "      <td>2017-12-29 04:00:00-05:00</td>\n",
+       "      <td>2017-12-29 09:30:00-05:00</td>\n",
+       "      <td>2017-12-29 16:00:00-05:00</td>\n",
+       "      <td>2017-12-29 20:00:00-05:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 pre               market_open  \\\n",
+       "2017-01-03 2017-01-03 04:00:00-05:00 2017-01-03 09:30:00-05:00   \n",
+       "2017-03-31 2017-03-31 04:00:00-04:00 2017-03-31 09:30:00-04:00   \n",
+       "2017-04-03 2017-04-03 04:00:00-04:00 2017-04-03 09:30:00-04:00   \n",
+       "2017-06-30 2017-06-30 04:00:00-04:00 2017-06-30 09:30:00-04:00   \n",
+       "2017-07-03 2017-07-03 04:00:00-04:00 2017-07-03 09:30:00-04:00   \n",
+       "2017-09-29 2017-09-29 04:00:00-04:00 2017-09-29 09:30:00-04:00   \n",
+       "2017-10-02 2017-10-02 04:00:00-04:00 2017-10-02 09:30:00-04:00   \n",
+       "2017-12-29 2017-12-29 04:00:00-05:00 2017-12-29 09:30:00-05:00   \n",
+       "\n",
+       "                        market_close                      post  \n",
+       "2017-01-03 2017-01-03 16:00:00-05:00 2017-01-03 20:00:00-05:00  \n",
+       "2017-03-31 2017-03-31 16:00:00-04:00 2017-03-31 20:00:00-04:00  \n",
+       "2017-04-03 2017-04-03 16:00:00-04:00 2017-04-03 20:00:00-04:00  \n",
+       "2017-06-30 2017-06-30 16:00:00-04:00 2017-06-30 20:00:00-04:00  \n",
+       "2017-07-03 2017-07-03 13:00:00-04:00 2017-07-03 13:00:00-04:00  \n",
+       "2017-09-29 2017-09-29 16:00:00-04:00 2017-09-29 20:00:00-04:00  \n",
+       "2017-10-02 2017-10-02 16:00:00-04:00 2017-10-02 20:00:00-04:00  \n",
+       "2017-12-29 2017-12-29 16:00:00-05:00 2017-12-29 20:00:00-05:00  "
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Example of how to get the first and last Trading Day of each Quarter in 2017\n",
+    "dates_end = nyse.date_range_htf('Q', start='2017-01-01', periods=4)\n",
+    "dates_start = nyse.date_range_htf('Q', start='2017-01-01', periods=4, closed='left')\n",
+    "nyse.schedule_from_days(dates_start.union(dates_end).sort_values(), market_times='all', tz=nyse.tz)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Get early closes"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 123,
    "metadata": {
     "scrolled": true
    },
@@ -614,7 +1127,7 @@
        "2012-07-03 2012-07-03 13:30:00+00:00 2012-07-03 17:00:00+00:00"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -625,7 +1138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 124,
    "metadata": {
     "scrolled": false
    },
@@ -677,7 +1190,7 @@
        "2012-07-03 2012-07-03 17:00:00+00:00 2012-07-03 17:00:00+00:00  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -716,7 +1229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [
     {
@@ -725,7 +1238,7 @@
        "False"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -743,7 +1256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [
     {
@@ -752,7 +1265,7 @@
        "True"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -770,7 +1283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [
     {
@@ -779,7 +1292,7 @@
        "False"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 128,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -804,7 +1317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 129,
    "metadata": {
     "tags": []
    },
@@ -839,7 +1352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [
     {
@@ -891,7 +1404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [
     {
@@ -927,7 +1440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [
     {
@@ -957,7 +1470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 133,
    "metadata": {
     "scrolled": true
    },
@@ -985,7 +1498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1002,7 +1515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 135,
    "metadata": {},
    "outputs": [
     {
@@ -1042,7 +1555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [
     {
@@ -1130,7 +1643,7 @@
        "2009-12-29 2009-12-29 21:00:00+00:00  "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1155,7 +1668,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 137,
    "metadata": {},
    "outputs": [
     {
@@ -1232,7 +1745,7 @@
        "2009-12-29 2009-12-29 21:00:00+00:00 2009-12-27 16:00:00+00:00  "
       ]
      },
-     "execution_count": 25,
+     "execution_count": 137,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1255,7 +1768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 138,
    "metadata": {},
    "outputs": [
     {
@@ -1310,7 +1823,7 @@
        "2009-12-28 2009-12-26 16:00:00+00:00 2009-12-28 21:00:00+00:00"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 138,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1322,7 +1835,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 139,
    "metadata": {
     "scrolled": false
    },
@@ -1379,7 +1892,7 @@
        "2009-12-28 2009-12-26 16:00:00+00:00 2009-12-28 21:00:00+00:00"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 139,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1419,9 +1932,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 140,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'pandas_market_calendars.exchange_calendar'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[140], line 5\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[38;5;66;03m# For example, CFEExchangeCalendar only has the regular trading hours for the futures exchange (8:30 - 15:15).\u001b[39;00m\n\u001b[0;32m      2\u001b[0m \u001b[38;5;66;03m# If you want to use the equity options exchange (8:30 - 15:00), including the order acceptance time at 7:30, and\u001b[39;00m\n\u001b[0;32m      3\u001b[0m \u001b[38;5;66;03m# some special cases when the order acceptance time was different, do this:\u001b[39;00m\n\u001b[1;32m----> 5\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mpandas_market_calendars\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mexchange_calendar\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcboe\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m CFEExchangeCalendar \n\u001b[0;32m      7\u001b[0m \u001b[38;5;28;01mclass\u001b[39;00m \u001b[38;5;21;01mDemoOptionsCalendar\u001b[39;00m(CFEExchangeCalendar):  \u001b[38;5;66;03m# Inherit what doesn't need to change\u001b[39;00m\n\u001b[0;32m      8\u001b[0m     name \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mDemo_Options\u001b[39m\u001b[38;5;124m\"\u001b[39m\n",
+      "\u001b[1;31mModuleNotFoundError\u001b[0m: No module named 'pandas_market_calendars.exchange_calendar'"
+     ]
+    }
+   ],
    "source": [
     "# For example, CFEExchangeCalendar only has the regular trading hours for the futures exchange (8:30 - 15:15).\n",
     "# If you want to use the equity options exchange (8:30 - 15:00), including the order acceptance time at 7:30, and\n",
@@ -2958,8 +3483,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Helpers\n",
-    "*schedules with columns other than market_open, break_start, break_end or market_close are not yet supported by the following functions*"
+    "# Helpers\n"
    ]
   },
   {
@@ -2973,72 +3497,766 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pre</th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>market_close</th>\n",
+       "      <th>post</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2012-07-02</th>\n",
+       "      <td>2012-07-02 04:00:00-04:00</td>\n",
+       "      <td>2012-07-02 09:30:00-04:00</td>\n",
+       "      <td>2012-07-02 16:00:00-04:00</td>\n",
+       "      <td>2012-07-02 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-03</th>\n",
+       "      <td>2012-07-03 04:00:00-04:00</td>\n",
+       "      <td>2012-07-03 09:30:00-04:00</td>\n",
+       "      <td>2012-07-03 13:00:00-04:00</td>\n",
+       "      <td>2012-07-03 13:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-05</th>\n",
+       "      <td>2012-07-05 04:00:00-04:00</td>\n",
+       "      <td>2012-07-05 09:30:00-04:00</td>\n",
+       "      <td>2012-07-05 16:00:00-04:00</td>\n",
+       "      <td>2012-07-05 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "DatetimeIndex(['2012-07-02 20:00:00+00:00', '2012-07-03 17:00:00+00:00',\n",
-       "               '2012-07-05 20:00:00+00:00', '2012-07-06 20:00:00+00:00',\n",
-       "               '2012-07-09 20:00:00+00:00', '2012-07-10 20:00:00+00:00'],\n",
-       "              dtype='datetime64[ns, UTC]', freq=None)"
+       "                                 pre               market_open  \\\n",
+       "2012-07-02 2012-07-02 04:00:00-04:00 2012-07-02 09:30:00-04:00   \n",
+       "2012-07-03 2012-07-03 04:00:00-04:00 2012-07-03 09:30:00-04:00   \n",
+       "2012-07-05 2012-07-05 04:00:00-04:00 2012-07-05 09:30:00-04:00   \n",
+       "\n",
+       "                        market_close                      post  \n",
+       "2012-07-02 2012-07-02 16:00:00-04:00 2012-07-02 20:00:00-04:00  \n",
+       "2012-07-03 2012-07-03 13:00:00-04:00 2012-07-03 13:00:00-04:00  \n",
+       "2012-07-05 2012-07-05 16:00:00-04:00 2012-07-05 20:00:00-04:00  "
       ]
      },
-     "execution_count": 65,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "mcal.date_range(early, frequency='1D')"
+    "import pandas_market_calendars as mcal\n",
+    "NYSE = mcal.get_calendar('NYSE')\n",
+    "nyse_schedule = NYSE.schedule('2012-07-02', '2012-07-05', market_times='all', tz=NYSE.tz)\n",
+    "nyse_schedule"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "DatetimeIndex(['2012-07-02 14:30:00+00:00', '2012-07-02 15:30:00+00:00',\n",
-       "               '2012-07-02 16:30:00+00:00', '2012-07-02 17:30:00+00:00',\n",
-       "               '2012-07-02 18:30:00+00:00', '2012-07-02 19:30:00+00:00',\n",
-       "               '2012-07-02 20:00:00+00:00', '2012-07-03 14:30:00+00:00',\n",
-       "               '2012-07-03 15:30:00+00:00', '2012-07-03 16:30:00+00:00',\n",
-       "               '2012-07-03 17:00:00+00:00', '2012-07-05 14:30:00+00:00',\n",
-       "               '2012-07-05 15:30:00+00:00', '2012-07-05 16:30:00+00:00',\n",
-       "               '2012-07-05 17:30:00+00:00', '2012-07-05 18:30:00+00:00',\n",
-       "               '2012-07-05 19:30:00+00:00', '2012-07-05 20:00:00+00:00',\n",
-       "               '2012-07-06 14:30:00+00:00', '2012-07-06 15:30:00+00:00',\n",
-       "               '2012-07-06 16:30:00+00:00', '2012-07-06 17:30:00+00:00',\n",
-       "               '2012-07-06 18:30:00+00:00', '2012-07-06 19:30:00+00:00',\n",
-       "               '2012-07-06 20:00:00+00:00', '2012-07-09 14:30:00+00:00',\n",
-       "               '2012-07-09 15:30:00+00:00', '2012-07-09 16:30:00+00:00',\n",
-       "               '2012-07-09 17:30:00+00:00', '2012-07-09 18:30:00+00:00',\n",
-       "               '2012-07-09 19:30:00+00:00', '2012-07-09 20:00:00+00:00',\n",
-       "               '2012-07-10 14:30:00+00:00', '2012-07-10 15:30:00+00:00',\n",
-       "               '2012-07-10 16:30:00+00:00', '2012-07-10 17:30:00+00:00',\n",
-       "               '2012-07-10 18:30:00+00:00', '2012-07-10 19:30:00+00:00',\n",
-       "               '2012-07-10 20:00:00+00:00'],\n",
-       "              dtype='datetime64[ns, UTC]', freq=None)"
+       "DatetimeIndex(['2012-07-02 16:00:00-04:00', '2012-07-03 13:00:00-04:00',\n",
+       "               '2012-07-05 16:00:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "mcal.date_range(early, frequency='1H')"
+    "# default is closed='right' & force_close=True => End-of-Period is returned\n",
+    "mcal.date_range(nyse_schedule, frequency='1D')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-02 09:30:00-04:00', '2012-07-03 09:30:00-04:00',\n",
+       "               '2012-07-05 09:30:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# closed='left' & force_close=False => start-of-Day is returned \n",
+    "# See function docstr for more info on these parameters\n",
+    "mcal.date_range(nyse_schedule, frequency='1D', closed='left', force_close=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-02 09:30:00-04:00', '2012-07-02 10:30:00-04:00',\n",
+       "               '2012-07-02 11:30:00-04:00', '2012-07-02 12:30:00-04:00',\n",
+       "               '2012-07-02 13:30:00-04:00', '2012-07-02 14:30:00-04:00',\n",
+       "               '2012-07-02 15:30:00-04:00', '2012-07-03 09:30:00-04:00',\n",
+       "               '2012-07-03 10:30:00-04:00', '2012-07-03 11:30:00-04:00',\n",
+       "               '2012-07-03 12:30:00-04:00', '2012-07-05 09:30:00-04:00',\n",
+       "               '2012-07-05 10:30:00-04:00', '2012-07-05 11:30:00-04:00',\n",
+       "               '2012-07-05 12:30:00-04:00', '2012-07-05 13:30:00-04:00',\n",
+       "               '2012-07-05 14:30:00-04:00', '2012-07-05 15:30:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mcal.date_range(nyse_schedule, frequency='1h', closed='left', force_close=False)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Merge schedules"
+    "### Advanced Date_Range() Arguments\n",
+    "\n",
+    "Date_Range returns Regular Trading Hours ('rth') by default, but all standard sessions (pre, rth, break, post, & closed) can be selected either individually or by listing them in an iterable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-02 04:00:00-04:00', '2012-07-02 05:00:00-04:00',\n",
+       "               '2012-07-02 06:00:00-04:00', '2012-07-02 07:00:00-04:00',\n",
+       "               '2012-07-02 08:00:00-04:00', '2012-07-02 09:00:00-04:00',\n",
+       "               '2012-07-02 16:00:00-04:00', '2012-07-02 17:00:00-04:00',\n",
+       "               '2012-07-02 18:00:00-04:00', '2012-07-02 19:00:00-04:00',\n",
+       "               '2012-07-03 04:00:00-04:00', '2012-07-03 05:00:00-04:00',\n",
+       "               '2012-07-03 06:00:00-04:00', '2012-07-03 07:00:00-04:00',\n",
+       "               '2012-07-03 08:00:00-04:00', '2012-07-03 09:00:00-04:00',\n",
+       "               '2012-07-05 04:00:00-04:00', '2012-07-05 05:00:00-04:00',\n",
+       "               '2012-07-05 06:00:00-04:00', '2012-07-05 07:00:00-04:00',\n",
+       "               '2012-07-05 08:00:00-04:00', '2012-07-05 09:00:00-04:00',\n",
+       "               '2012-07-05 16:00:00-04:00', '2012-07-05 17:00:00-04:00',\n",
+       "               '2012-07-05 18:00:00-04:00', '2012-07-05 19:00:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mcal.date_range(nyse_schedule, frequency='1h', session='ETH', closed='left', force_close=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-02 04:00:00-04:00', '2012-07-02 05:00:00-04:00',\n",
+       "               '2012-07-02 06:00:00-04:00', '2012-07-02 07:00:00-04:00',\n",
+       "               '2012-07-02 08:00:00-04:00', '2012-07-02 09:00:00-04:00',\n",
+       "               '2012-07-02 10:00:00-04:00', '2012-07-02 11:00:00-04:00',\n",
+       "               '2012-07-02 12:00:00-04:00', '2012-07-02 13:00:00-04:00',\n",
+       "               '2012-07-02 14:00:00-04:00', '2012-07-02 15:00:00-04:00',\n",
+       "               '2012-07-02 16:00:00-04:00', '2012-07-02 17:00:00-04:00',\n",
+       "               '2012-07-02 18:00:00-04:00', '2012-07-02 19:00:00-04:00',\n",
+       "               '2012-07-03 04:00:00-04:00', '2012-07-03 05:00:00-04:00',\n",
+       "               '2012-07-03 06:00:00-04:00', '2012-07-03 07:00:00-04:00',\n",
+       "               '2012-07-03 08:00:00-04:00', '2012-07-03 09:00:00-04:00',\n",
+       "               '2012-07-03 10:00:00-04:00', '2012-07-03 11:00:00-04:00',\n",
+       "               '2012-07-03 12:00:00-04:00', '2012-07-05 04:00:00-04:00',\n",
+       "               '2012-07-05 05:00:00-04:00', '2012-07-05 06:00:00-04:00',\n",
+       "               '2012-07-05 07:00:00-04:00', '2012-07-05 08:00:00-04:00',\n",
+       "               '2012-07-05 09:00:00-04:00', '2012-07-05 10:00:00-04:00',\n",
+       "               '2012-07-05 11:00:00-04:00', '2012-07-05 12:00:00-04:00',\n",
+       "               '2012-07-05 13:00:00-04:00', '2012-07-05 14:00:00-04:00',\n",
+       "               '2012-07-05 15:00:00-04:00', '2012-07-05 16:00:00-04:00',\n",
+       "               '2012-07-05 17:00:00-04:00', '2012-07-05 18:00:00-04:00',\n",
+       "               '2012-07-05 19:00:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mcal.date_range(nyse_schedule, frequency='1h', session={'ETH', 'RTH'}, closed='left', force_close=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This last example poses a bit of an issue, the pre-market session starts a 4AM, but the market opens at 9:30AM. When requesting an Interval of '1h' there will be a period every day where one of the intervals is in both the pre-market and rth sessions. This is the default since it maintains a constant time delta between each timestamp.\n",
+    "\n",
+    "However, the argument merge_adjacent can be set to False to keep adjacent sessions separated. This re-aligns the timestamps to the underlying session at the cost of having a time delta that isn't constant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-02 04:00:00-04:00', '2012-07-02 05:00:00-04:00',\n",
+       "               '2012-07-02 06:00:00-04:00', '2012-07-02 07:00:00-04:00',\n",
+       "               '2012-07-02 08:00:00-04:00', '2012-07-02 09:00:00-04:00',\n",
+       "               '2012-07-02 09:30:00-04:00', '2012-07-02 10:30:00-04:00',\n",
+       "               '2012-07-02 11:30:00-04:00', '2012-07-02 12:30:00-04:00',\n",
+       "               '2012-07-02 13:30:00-04:00', '2012-07-02 14:30:00-04:00',\n",
+       "               '2012-07-02 15:30:00-04:00', '2012-07-02 16:00:00-04:00',\n",
+       "               '2012-07-02 17:00:00-04:00', '2012-07-02 18:00:00-04:00',\n",
+       "               '2012-07-02 19:00:00-04:00', '2012-07-03 04:00:00-04:00',\n",
+       "               '2012-07-03 05:00:00-04:00', '2012-07-03 06:00:00-04:00',\n",
+       "               '2012-07-03 07:00:00-04:00', '2012-07-03 08:00:00-04:00',\n",
+       "               '2012-07-03 09:00:00-04:00', '2012-07-03 09:30:00-04:00',\n",
+       "               '2012-07-03 10:30:00-04:00', '2012-07-03 11:30:00-04:00',\n",
+       "               '2012-07-03 12:30:00-04:00', '2012-07-05 04:00:00-04:00',\n",
+       "               '2012-07-05 05:00:00-04:00', '2012-07-05 06:00:00-04:00',\n",
+       "               '2012-07-05 07:00:00-04:00', '2012-07-05 08:00:00-04:00',\n",
+       "               '2012-07-05 09:00:00-04:00', '2012-07-05 09:30:00-04:00',\n",
+       "               '2012-07-05 10:30:00-04:00', '2012-07-05 11:30:00-04:00',\n",
+       "               '2012-07-05 12:30:00-04:00', '2012-07-05 13:30:00-04:00',\n",
+       "               '2012-07-05 14:30:00-04:00', '2012-07-05 15:30:00-04:00',\n",
+       "               '2012-07-05 16:00:00-04:00', '2012-07-05 17:00:00-04:00',\n",
+       "               '2012-07-05 18:00:00-04:00', '2012-07-05 19:00:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mcal.date_range(nyse_schedule, frequency='1h', session={'ETH', 'RTH'}, closed='left', force_close=False, merge_adjacent=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As long as the Dates are Covered by the given schedule, Date Range also Supports Custom Start, End and Period Parameters in the exact same manner that pandas' date_range() function does. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-02 13:30:00-04:00', '2012-07-02 14:30:00-04:00',\n",
+       "               '2012-07-02 15:30:00-04:00', '2012-07-03 09:30:00-04:00',\n",
+       "               '2012-07-03 10:30:00-04:00', '2012-07-03 11:30:00-04:00',\n",
+       "               '2012-07-03 12:30:00-04:00', '2012-07-05 09:30:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mcal.date_range(nyse_schedule, frequency='1h', start='2012-07-02 13:30:00-04:00', periods=8, closed='left', force_close=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-02 14:30:00-04:00', '2012-07-02 15:30:00-04:00',\n",
+       "               '2012-07-03 09:30:00-04:00', '2012-07-03 10:30:00-04:00',\n",
+       "               '2012-07-03 11:30:00-04:00', '2012-07-03 12:30:00-04:00',\n",
+       "               '2012-07-05 09:30:00-04:00', '2012-07-05 10:30:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Note: When requesting a custom start or end timestamp the returned result will always align\n",
+    "# with the underlying session and frequency given. \n",
+    "mcal.date_range(nyse_schedule, frequency='1h', start='2012-07-02 13:34:39-04:00', periods=8, closed='left', force_close=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-02 13:30:00-04:00', '2012-07-02 14:30:00-04:00',\n",
+       "               '2012-07-02 15:30:00-04:00', '2012-07-03 09:30:00-04:00',\n",
+       "               '2012-07-03 10:30:00-04:00', '2012-07-03 11:30:00-04:00',\n",
+       "               '2012-07-03 12:30:00-04:00', '2012-07-05 09:30:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Start/End Timestamps without TZ information are interpreted in the timezone given by the schedule.\n",
+    "mcal.date_range(nyse_schedule, frequency='1h', start='2012-07-02 13:30', periods=8, closed='left', force_close=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Escalating / Ignoring Date_Range Warnings\n",
+    "\n",
+    "There Are a few different warnings thrown by date_range:\n",
+    "- DateRangeWarning (Super Class to other warnings)\n",
+    "- InsufficientScheduleWarning,\n",
+    "- MissingSessionWarning, \n",
+    "- OverlappingSessionWarning\n",
+    "- DisappearingSessionWarning\n",
+    "\n",
+    "For Example, Below the given start, # of periods, and frequency result in a date range that extends beyond the last date in the schedule. A Warning is thrown and the portion of the date_range that was generated is returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\bryce\\Documents\\GitHub\\pandas_market_calendars\\pandas_market_calendars\\calendar_utils.py:765: InsufficientScheduleWarning: Insufficient Schedule. Requested Approx End-Time: 2012-07-13 09:30:00-04:00. Schedule ends at: 2012-07-05 00:00:00\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-05 15:30:00-04:00'], dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nyse_schedule = NYSE.schedule('2012-07-02', '2012-07-05', market_times='all', tz=NYSE.tz)\n",
+    "problematic_date_range_args = lambda: mcal.date_range(nyse_schedule, frequency='1h', start='2012-07-05 15:30', periods=8, closed='left', force_close=False)\n",
+    "problematic_date_range_args()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-05 15:30:00-04:00'], dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas_market_calendars.calendar_utils as mcal_util\n",
+    "\n",
+    "# This warning can be ignored\n",
+    "mcal_util.filter_date_range_warnings('ignore', mcal_util.InsufficientScheduleWarning)\n",
+    "nyse_schedule = NYSE.schedule('2012-07-02', '2012-07-05', market_times='all', tz=NYSE.tz)\n",
+    "problematic_date_range_args()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error Thrown: Insufficient Schedule. Requested Approx End-Time: 2012-07-13 09:30:00-04:00. Schedule ends at: 2012-07-05 00:00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Or It can be escalated into an Error\n",
+    "mcal_util.filter_date_range_warnings('error', mcal_util.InsufficientScheduleWarning)\n",
+    "nyse_schedule = NYSE.schedule('2012-07-02', '2012-07-05', market_times='all', tz=NYSE.tz)\n",
+    "try:\n",
+    "    problematic_date_range_args()\n",
+    "except Exception as e:\n",
+    "    print(f'Error Thrown: {e}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DatetimeIndex(['2012-07-05 15:30:00-04:00', '2012-07-06 09:30:00-04:00',\n",
+       "               '2012-07-06 10:30:00-04:00', '2012-07-06 11:30:00-04:00',\n",
+       "               '2012-07-06 12:30:00-04:00', '2012-07-06 13:30:00-04:00',\n",
+       "               '2012-07-06 14:30:00-04:00', '2012-07-06 15:30:00-04:00'],\n",
+       "              dtype='datetime64[ns, America/New_York]', freq=None)"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from pytest import mark\n",
+    "# When Escalated into an Error, it can be caught and processed\n",
+    "try:\n",
+    "    nyse_schedule = NYSE.schedule('2012-07-02', '2012-07-05', market_times='all', tz=NYSE.tz)\n",
+    "    dt = problematic_date_range_args()\n",
+    "except mcal_util.InsufficientScheduleWarning as w:\n",
+    "    # When this Warning is thrown from a date_range call that requests a # of periods\n",
+    "    # it over estimates the needed date by about 1 week to ensure that a second warning\n",
+    "    # is not thrown when doing this.\n",
+    "    beginning, start, end = mcal_util.parse_insufficient_schedule_warning(w)\n",
+    "    extra_dates_needed = NYSE.schedule(start, end, tz=NYSE.tz, market_times='all')\n",
+    "    if beginning:\n",
+    "        nyse_schedule = pd.concat([extra_dates_needed, nyse_schedule])\n",
+    "    else:\n",
+    "        nyse_schedule = pd.concat([nyse_schedule, extra_dates_needed])\n",
+    "\n",
+    "    # Call the Function again to get the desired result\n",
+    "    dt = problematic_date_range_args()\n",
+    "dt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>pre</th>\n",
+       "      <th>market_open</th>\n",
+       "      <th>market_close</th>\n",
+       "      <th>post</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2012-07-02</th>\n",
+       "      <td>2012-07-02 04:00:00-04:00</td>\n",
+       "      <td>2012-07-02 09:30:00-04:00</td>\n",
+       "      <td>2012-07-02 16:00:00-04:00</td>\n",
+       "      <td>2012-07-02 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-03</th>\n",
+       "      <td>2012-07-03 04:00:00-04:00</td>\n",
+       "      <td>2012-07-03 09:30:00-04:00</td>\n",
+       "      <td>2012-07-03 13:00:00-04:00</td>\n",
+       "      <td>2012-07-03 13:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-05</th>\n",
+       "      <td>2012-07-05 04:00:00-04:00</td>\n",
+       "      <td>2012-07-05 09:30:00-04:00</td>\n",
+       "      <td>2012-07-05 16:00:00-04:00</td>\n",
+       "      <td>2012-07-05 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-06</th>\n",
+       "      <td>2012-07-06 04:00:00-04:00</td>\n",
+       "      <td>2012-07-06 09:30:00-04:00</td>\n",
+       "      <td>2012-07-06 16:00:00-04:00</td>\n",
+       "      <td>2012-07-06 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-09</th>\n",
+       "      <td>2012-07-09 04:00:00-04:00</td>\n",
+       "      <td>2012-07-09 09:30:00-04:00</td>\n",
+       "      <td>2012-07-09 16:00:00-04:00</td>\n",
+       "      <td>2012-07-09 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-10</th>\n",
+       "      <td>2012-07-10 04:00:00-04:00</td>\n",
+       "      <td>2012-07-10 09:30:00-04:00</td>\n",
+       "      <td>2012-07-10 16:00:00-04:00</td>\n",
+       "      <td>2012-07-10 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-11</th>\n",
+       "      <td>2012-07-11 04:00:00-04:00</td>\n",
+       "      <td>2012-07-11 09:30:00-04:00</td>\n",
+       "      <td>2012-07-11 16:00:00-04:00</td>\n",
+       "      <td>2012-07-11 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-12</th>\n",
+       "      <td>2012-07-12 04:00:00-04:00</td>\n",
+       "      <td>2012-07-12 09:30:00-04:00</td>\n",
+       "      <td>2012-07-12 16:00:00-04:00</td>\n",
+       "      <td>2012-07-12 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2012-07-13</th>\n",
+       "      <td>2012-07-13 04:00:00-04:00</td>\n",
+       "      <td>2012-07-13 09:30:00-04:00</td>\n",
+       "      <td>2012-07-13 16:00:00-04:00</td>\n",
+       "      <td>2012-07-13 20:00:00-04:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 pre               market_open  \\\n",
+       "2012-07-02 2012-07-02 04:00:00-04:00 2012-07-02 09:30:00-04:00   \n",
+       "2012-07-03 2012-07-03 04:00:00-04:00 2012-07-03 09:30:00-04:00   \n",
+       "2012-07-05 2012-07-05 04:00:00-04:00 2012-07-05 09:30:00-04:00   \n",
+       "2012-07-06 2012-07-06 04:00:00-04:00 2012-07-06 09:30:00-04:00   \n",
+       "2012-07-09 2012-07-09 04:00:00-04:00 2012-07-09 09:30:00-04:00   \n",
+       "2012-07-10 2012-07-10 04:00:00-04:00 2012-07-10 09:30:00-04:00   \n",
+       "2012-07-11 2012-07-11 04:00:00-04:00 2012-07-11 09:30:00-04:00   \n",
+       "2012-07-12 2012-07-12 04:00:00-04:00 2012-07-12 09:30:00-04:00   \n",
+       "2012-07-13 2012-07-13 04:00:00-04:00 2012-07-13 09:30:00-04:00   \n",
+       "\n",
+       "                        market_close                      post  \n",
+       "2012-07-02 2012-07-02 16:00:00-04:00 2012-07-02 20:00:00-04:00  \n",
+       "2012-07-03 2012-07-03 13:00:00-04:00 2012-07-03 13:00:00-04:00  \n",
+       "2012-07-05 2012-07-05 16:00:00-04:00 2012-07-05 20:00:00-04:00  \n",
+       "2012-07-06 2012-07-06 16:00:00-04:00 2012-07-06 20:00:00-04:00  \n",
+       "2012-07-09 2012-07-09 16:00:00-04:00 2012-07-09 20:00:00-04:00  \n",
+       "2012-07-10 2012-07-10 16:00:00-04:00 2012-07-10 20:00:00-04:00  \n",
+       "2012-07-11 2012-07-11 16:00:00-04:00 2012-07-11 20:00:00-04:00  \n",
+       "2012-07-12 2012-07-12 16:00:00-04:00 2012-07-12 20:00:00-04:00  \n",
+       "2012-07-13 2012-07-13 16:00:00-04:00 2012-07-13 20:00:00-04:00  "
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nyse_schedule # The Updated Nyse_Schedule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mark Session\n",
+    "\n",
+    "Returns a series identifying a given DatetimeIndex with the trading session it belongs in.\n",
+    "The series values are the timestamp's session and the Index is the original DatetimeIndex passed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2012-07-05 04:00:00-04:00     pre\n",
+       "2012-07-05 06:00:00-04:00     pre\n",
+       "2012-07-05 08:00:00-04:00     pre\n",
+       "2012-07-05 10:00:00-04:00     rth\n",
+       "2012-07-05 12:00:00-04:00     rth\n",
+       "2012-07-05 14:00:00-04:00     rth\n",
+       "2012-07-05 16:00:00-04:00    post\n",
+       "2012-07-05 18:00:00-04:00    post\n",
+       "2012-07-06 04:00:00-04:00     pre\n",
+       "2012-07-06 06:00:00-04:00     pre\n",
+       "dtype: category\n",
+       "Categories (4, object): ['closed', 'post', 'pre', 'rth']"
+      ]
+     },
+     "execution_count": 144,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dt = mcal.date_range(nyse_schedule, '2h', start='2012-07-05 04:00:00', periods=10, session={'RTH','ETH'}, closed='left', force_close=None)\n",
+    "mcal.mark_session(nyse_schedule, dt, closed='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2012-07-05 04:00:00-04:00     pre\n",
+       "2012-07-05 06:00:00-04:00     pre\n",
+       "2012-07-05 08:00:00-04:00     pre\n",
+       "2012-07-05 09:30:00-04:00     rth\n",
+       "2012-07-05 11:30:00-04:00     rth\n",
+       "2012-07-05 13:30:00-04:00     rth\n",
+       "2012-07-05 15:30:00-04:00     rth\n",
+       "2012-07-05 16:00:00-04:00    post\n",
+       "2012-07-05 18:00:00-04:00    post\n",
+       "2012-07-06 04:00:00-04:00     pre\n",
+       "dtype: category\n",
+       "Categories (4, object): ['closed', 'post', 'pre', 'rth']"
+      ]
+     },
+     "execution_count": 147,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This makes it much easier to identify nuances in date_range() results like the \n",
+    "# one described above in the date_range(merge_adjacent=True/False) discussion\n",
+    "dt = mcal.date_range(nyse_schedule, '2h', start='2012-07-05 04:00:00', periods=10, merge_adjacent=False, session={'RTH','ETH'}, closed='left', force_close=None)\n",
+    "mcal.mark_session(nyse_schedule, dt, closed='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 142,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2012-07-05 04:00:00-04:00    eth\n",
+       "2012-07-05 06:00:00-04:00    eth\n",
+       "2012-07-05 08:00:00-04:00    eth\n",
+       "2012-07-05 09:30:00-04:00    rth\n",
+       "2012-07-05 11:30:00-04:00    rth\n",
+       "2012-07-05 13:30:00-04:00    rth\n",
+       "2012-07-05 15:30:00-04:00    rth\n",
+       "2012-07-05 16:00:00-04:00    eth\n",
+       "2012-07-05 18:00:00-04:00    eth\n",
+       "2012-07-06 04:00:00-04:00    eth\n",
+       "dtype: category\n",
+       "Categories (3, object): ['closed', 'eth', 'rth']"
+      ]
+     },
+     "execution_count": 142,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# User Defined Names for each session can be passed in an optional dictionary\n",
+    "# While only strings are shown, the dictionary values can be any basic type.\n",
+    "mcal.mark_session(nyse_schedule, dt, closed='left', label_map={'pre':'eth', 'post':'eth'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Merge schedules\n",
+    "Merge two schedule producing either the Union ('outer') or Intersection ('inner') of the given market dates.\n",
+    "\n",
+    "*This function does not yet support schedules with columns other than market_open, break_start, break_end or market_close*"
    ]
   },
   {

--- a/pandas_market_calendars/__init__.py
+++ b/pandas_market_calendars/__init__.py
@@ -17,7 +17,7 @@
 from importlib import metadata
 
 from .calendar_registry import get_calendar, get_calendar_names
-from .calendar_utils import convert_freq, date_range, merge_schedules
+from .calendar_utils import convert_freq, date_range, merge_schedules, mark_session
 
 # TODO: is the below needed? Can I replace all the imports on the calendars with ".market_calendar"
 from .market_calendar import MarketCalendar
@@ -34,5 +34,6 @@ __all__ = [
     "get_calendar_names",
     "merge_schedules",
     "date_range",
+    "mark_session",
     "convert_freq",
 ]

--- a/pandas_market_calendars/calendars/iex.py
+++ b/pandas_market_calendars/calendars/iex.py
@@ -1,6 +1,7 @@
 from datetime import time
 from itertools import chain
 
+from pandas import Timestamp
 from pandas.tseries.holiday import AbstractHolidayCalendar
 from pytz import timezone
 
@@ -106,7 +107,11 @@ class IEXExchangeCalendar(NYSEExchangeCalendar):
         return []
 
     def valid_days(self, start_date, end_date, tz="UTC"):
-        trading_days = super().valid_days(
-            start_date, end_date, tz=tz
-        )  # all NYSE valid days
-        return trading_days[~(trading_days <= "2013-08-25")]
+        start_date = Timestamp(start_date)
+        if start_date.tz is not None:
+            # Ensure valid Comparison to "2013-08-25" is possible
+            start_date.tz_convert(self.tz).tz_localize(None)
+
+        # Limit Start_date to the Exchange's Open
+        start_date = max(start_date, Timestamp("2013-08-25"))
+        return super().valid_days(start_date, end_date, tz=tz)

--- a/pandas_market_calendars/calendars/iex.py
+++ b/pandas_market_calendars/calendars/iex.py
@@ -1,9 +1,12 @@
 from datetime import time
 from itertools import chain
 
-from pandas import Timestamp
+from pandas import Timestamp, DatetimeIndex, Timedelta
 from pandas.tseries.holiday import AbstractHolidayCalendar
 from pytz import timezone
+
+from typing import Literal, Union
+from pandas_market_calendars import calendar_utils as u
 
 from pandas_market_calendars.holidays.nyse import (
     USPresidentsDay,
@@ -115,3 +118,34 @@ class IEXExchangeCalendar(NYSEExchangeCalendar):
         # Limit Start_date to the Exchange's Open
         start_date = max(start_date, Timestamp("2013-08-25"))
         return super().valid_days(start_date, end_date, tz=tz)
+
+    def date_range_htf(
+        self,
+        frequency: Union[str, Timedelta, int, float],
+        start: Union[str, Timestamp, int, float, None] = None,
+        end: Union[str, Timestamp, int, float, None] = None,
+        periods: Union[int, None] = None,
+        closed: Union[Literal["left", "right"], None] = "right",
+        *,
+        day_anchor: u.Day_Anchor = "SUN",
+        month_anchor: u.Month_Anchor = "JAN",
+    ) -> DatetimeIndex:
+
+        start, end, periods = u._error_check_htf_range(start, end, periods)
+
+        # Cap Beginning and end dates to the opening date of IEX
+        if start is not None:
+            start = max(start, Timestamp("2013-08-25"))
+        if end is not None:
+            end = max(end, Timestamp("2013-08-25"))
+
+        return u.date_range_htf(
+            self.holidays(),
+            frequency,
+            start,
+            end,
+            periods,
+            closed,
+            day_anchor=day_anchor,
+            month_anchor=month_anchor,
+        )

--- a/pandas_market_calendars/calendars/tase.py
+++ b/pandas_market_calendars/calendars/tase.py
@@ -1,9 +1,11 @@
 from datetime import time
 
-from pandas import Timestamp
+from typing import Literal, Union
+from pandas import Timestamp, Timedelta, DatetimeIndex
 from pytz import timezone
 
 from pandas_market_calendars.market_calendar import MarketCalendar
+from pandas_market_calendars.calendar_utils import Day_Anchor, Month_Anchor
 
 TASEClosedDay = [
     # 2019
@@ -195,3 +197,24 @@ class TASEExchangeCalendar(MarketCalendar):
     @property
     def weekmask(self):
         return "Sun Mon Tue Wed Thu"
+
+    def date_range_htf(
+        self,
+        frequency: Union[str, Timedelta, int, float],
+        start: Union[str, Timestamp, int, float, None] = None,
+        end: Union[str, Timestamp, int, float, None] = None,
+        periods: Union[int, None] = None,
+        closed: Union[Literal["left", "right"], None] = "right",
+        *,
+        day_anchor: Day_Anchor = "SAT",  # Change the default day anchor
+        month_anchor: Month_Anchor = "JAN",
+    ) -> DatetimeIndex:
+        return super().date_range_htf(
+            frequency,
+            start,
+            end,
+            periods,
+            closed,
+            day_anchor=day_anchor,
+            month_anchor=month_anchor,
+        )

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -16,11 +16,14 @@
 import warnings
 from abc import ABCMeta, abstractmethod
 from datetime import time
+from typing import Literal, Union
 
 import pandas as pd
 from pandas.tseries.offsets import CustomBusinessDay
 
 from .class_registry import RegisteryMeta, ProtectedDict
+
+from . import calendar_utils as u
 
 MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY = range(7)
 
@@ -550,7 +553,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
         return intr.apply(self._convert).sort_index()
 
-    def holidays(self):
+    def holidays(self) -> pd.tseries.offsets.CustomBusinessDay:
         """
         Returns the complete CustomBusinessDay object of holidays that can be used in any Pandas function that take
         that input.
@@ -567,7 +570,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             )
         return self._holidays
 
-    def valid_days(self, start_date, end_date, tz="UTC"):
+    def valid_days(self, start_date, end_date, tz="UTC") -> pd.DatetimeIndex:
         """
         Get a DatetimeIndex of valid open business days.
 
@@ -627,7 +630,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         try:
             # If the Calendar is all single Observance Holidays then it is far
             # more efficient to extract and return those dates
-            observed_dates = _all_single_observance_rules(cal)
+            observed_dates = u.all_single_observance_rules(cal)
             if observed_dates is not None:
                 return pd.DatetimeIndex(
                     [date for date in observed_dates if s <= date <= e]
@@ -700,7 +703,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         force_special_times=True,
         market_times=None,
         interruptions=False,
-    ):
+    ) -> pd.DataFrame:
         """
         Generates the schedule DataFrame. The resulting DataFrame will have all the valid business days as the index
         and columns for the requested market times. The columns can be determined either by setting a range (inclusive
@@ -732,18 +735,71 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         if not (start_date <= end_date):
             raise ValueError("start_date must be before or equal to end_date.")
 
-        # Setup all valid trading days and the requested market_times
         _all_days = self.valid_days(start_date, end_date)
+
+        # Setup all valid trading days and the requested market_times
         if market_times is None:
             market_times = self._get_market_times(start, end)
         elif market_times == "all":
             market_times = self._market_times
 
-        # If no valid days return an empty DataFrame
-        if not _all_days.size:
+        if not _all_days.size:  # If no valid days return an empty DataFrame
             return pd.DataFrame(
                 columns=market_times, index=pd.DatetimeIndex([], freq="C")
             )
+
+        return self.schedule_from_days(
+            _all_days, tz, start, end, force_special_times, market_times, interruptions
+        )
+
+    def schedule_from_days(
+        self,
+        days: pd.DatetimeIndex,
+        tz="UTC",
+        start="market_open",
+        end="market_close",
+        force_special_times=True,
+        market_times=None,
+        interruptions=False,
+    ) -> pd.DataFrame:
+        """
+        Generates a schedule DataFrame for the days provided. The days are assumed to be valid trading days.
+
+        The columns can be determined either by setting a range (inclusive on both sides), using `start` and `end`,
+        or by passing a list to `market_times'. A range of market_times is derived from a list of market_times that
+        are available to the instance, which are sorted based on the current regular time.
+        See examples/usage.ipynb for demonstrations.
+
+        All time zones are set to UTC by default. Setting the tz parameter will convert the columns to the desired
+        timezone, such as 'America/New_York'.
+
+        :param days: pd.DatetimeIndex of all the desired days in ascending order. This function does not double check
+            that these are valid trading days, it is assumed they are. It is intended that this parameter is generated
+            by either the .valid_days() or .date_range_htf() methods. Time & Timezone Information is ignored.
+        :param tz: timezone that the columns of the returned schedule are in, default: "UTC"
+        :param start: the first market_time to include as a column, default: "market_open"
+        :param end: the last market_time to include as a column, default: "market_close"
+        :param force_special_times: how to handle special times.
+            True: overwrite regular times of the column itself, conform other columns to special times of
+                market_open/market_close if those are requested.
+            False: only overwrite regular times of the column itself, leave others alone
+            None: completely ignore special times
+        :param market_times: alternative to start/end, list of market_times that are in self.regular_market_times
+        :param interruptions: bool, whether to add interruptions to the schedule, default: False
+            These will be added as columns to the right of the DataFrame. Any interruption on a day between
+            start_date and end_date will be included, regardless of the market_times requested.
+            Also, `force_special_times` does not take these into consideration.
+        :return: schedule DataFrame
+        """
+
+        if days.dtype != "datetime64[ns]":
+            days = pd.DatetimeIndex(days).normalize().tz_localize(None)
+
+        # Setup all valid trading days and the requested market_times
+        if market_times is None:
+            market_times = self._get_market_times(start, end)
+        elif market_times == "all":
+            market_times = self._market_times
 
         _adj_others = force_special_times is True
         _adj_col = force_special_times is not None
@@ -751,11 +807,11 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
         schedule = pd.DataFrame()
         for market_time in market_times:
-            temp = self.days_at_time(_all_days, market_time).copy()  # standard times
+            temp = self.days_at_time(days, market_time).copy()  # standard times
             if _adj_col:
                 # create an array of special times
                 special = self.special_dates(
-                    market_time, start_date, end_date, filter_holidays=False
+                    market_time, days[0], days[-1], filter_holidays=False
                 )
                 # overwrite standard times
                 specialix = special.index[
@@ -802,6 +858,66 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             schedule = schedule.apply(lambda s: s.dt.tz_convert(tz))
 
         return schedule
+
+    def date_range_htf(
+        self,
+        frequency: Union[str, pd.Timedelta, int, float],
+        start: Union[str, pd.Timestamp, int, float, None] = None,
+        end: Union[str, pd.Timestamp, int, float, None] = None,
+        periods: Union[int, None] = None,
+        closed: Union[Literal["left", "right"], None] = "right",
+        *,
+        day_anchor: u.Day_Anchor = "SUN",
+        month_anchor: u.Month_Anchor = "JAN",
+    ) -> pd.DatetimeIndex:
+        """
+        Returns a Normalized DatetimeIndex from the start-date to End-Date for Time periods of 1D and Higher.
+
+        PARAMETERS:
+
+        :param frequency: String, Int/float (POSIX seconds) or pd.Timedelta of the desired frequency.
+            :Must be Greater than '1D' and an integer multiple of the base frequency (D, W, M, Q, or Y)
+            :Important Note: Ints/Floats & Timedeltas are always considered as 'Open Business Days',
+                '2D' == Every Other Buisness Day, '3D' == Every 3rd B.Day, '7D' == Every 7th B.Day
+            :Higher periods (passed as strings) align to the beginning or end of the relevant period
+            :i.e. '1W' == First/[Last] Trading Day of each Week, '1Q' == First/[Last] Day of every Quarter
+
+        :param start: String, Int/float (POSIX seconds) or pd.Timestamp of the desired start time.
+            :The Time & Timezone information is ignored. Only the Normalized Day is considered.
+
+        :param end: String, Int/float (POSIX seconds) or pd.Timestamp of the desired start time.
+            :The Time & Timezone information is ignored. Only the Normalized Day is considered.
+
+        :param periods: Optional Integer number of periods to return. If a Period count, Start time,
+            and End time are given the period count is ignored.
+
+        :param closed: Literal['left', 'right']. Method used to close each range.
+            :Left: First open trading day of the Session is returned (e.g. First Open Day of The Month)
+            :right: Last open trading day of the Session is returned (e.g. Last Open Day of The Month)
+            :Note, This has no effect when the desired frequency is a number of days.
+
+        :param day_anchor: Day to Anchor the start of the Weekly timeframes to. Default 'SUN'.
+            : To get the First/Last Days of the trading Week then the Anchor needs to be on a day the relevant
+                market is closed.
+            : This can be set so that a specific day each week is returned.
+            : freq='1W' & day_anchor='WED' Will return Every 'WED' when the market is open, and nearest day
+                to the left or right (based on 'closed') when the market is closed.
+            Options: ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+
+        :param month_anchor: Month to Anchor the start of the year to for Quarter and yearly timeframes.
+            : Default 'JAN' for Calendar Quarters/Years. Can be set to 'JUL' to return Fiscal Years
+            Options: ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"]
+        """
+        return u.date_range_htf(
+            self.holidays(),
+            frequency,
+            start,
+            end,
+            periods,
+            closed,
+            day_anchor=day_anchor,
+            month_anchor=month_anchor,
+        )
 
     def open_at_time(self, schedule, timestamp, include_close=False, only_rth=False):
         """
@@ -939,14 +1055,3 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
     def __delitem__(self, key):
         return self.remove_time(key)
-
-
-def _is_single_observance(holiday):
-    "Returns the Date of the Holiday if it is only observed once, None otherwise."
-    return holiday.start_date if holiday.start_date == holiday.end_date else None
-
-
-def _all_single_observance_rules(calendar):
-    "Returns a list of timestamps if the Calendar's Rules are all single observance holidays, None Otherwise"
-    observances = [_is_single_observance(rule) for rule in calendar.rules]
-    return observances if all(observances) else None

--- a/tests/test_iex_calendar.py
+++ b/tests/test_iex_calendar.py
@@ -38,3 +38,9 @@ def test_calendar_utility():
 def test_trading_days_before_operation():
     trading_days = iex.valid_days(start_date="2000-01-01", end_date="2022-02-23")
     assert np.array([~(trading_days <= "2013-08-25")]).any()
+
+    trading_days = iex.date_range_htf("1D", "2000-01-01", "2022-02-23")
+    assert np.array([~(trading_days <= "2013-08-25")]).any()
+
+    trading_days = iex.date_range_htf("1D", "2000-01-01", "2010-02-23")
+    assert len(trading_days) == 0

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -493,7 +493,7 @@ def test_days_at_time():
 
     def dat(day, day_offset, time_offset, cal, expected):
         days = pd.DatetimeIndex([pd.Timestamp(day, tz=cal.tz)])
-        result = cal.days_at_time(days, time_offset, day_offset)[0]
+        result = cal.days_at_time(days, time_offset, day_offset).iloc[0]
         expected = pd.Timestamp(expected, tz=cal.tz).tz_convert("UTC")
         assert result == expected
 

--- a/tests/test_nyse_calendar_early_years.py
+++ b/tests/test_nyse_calendar_early_years.py
@@ -22,7 +22,7 @@ def test_close_time_tz():
 
 
 def test_weekmask():
-    assert nyse.weekmask == "Mon Tue Wed Thu Fri Sat"
+    assert nyse.holidays_pre_1952().weekmask == "Mon Tue Wed Thu Fri Sat"
 
 
 def _test_holidays(holidays, start, end):

--- a/tests/test_nyse_calendar_early_years.py
+++ b/tests/test_nyse_calendar_early_years.py
@@ -2048,6 +2048,137 @@ def test_1952_no_saturdays():
     assert len(df) == 0
 
 
+def test_1952_date_range_htf_crossover():
+    # Test that Date_Range_HTF can produce the correct range when having
+    # to merge ranges from two different holiday objects. This is only
+    # A massive pain in the ass when closed='right'
+    nyse = NYSEExchangeCalendar()
+
+    actual_week_ends = pd.DatetimeIndex(
+        [
+            "1952-01-05",  # Saturday
+            "1952-01-12",  # Saturday
+            "1952-01-19",  # Saturday
+            "1952-01-26",  # Saturday
+            "1952-02-02",  # Saturday
+            "1952-02-09",  # Saturday
+            "1952-02-16",  # Saturday
+            "1952-02-23",  # Saturday
+            "1952-03-01",  # Saturday
+            "1952-03-08",  # Saturday
+            "1952-03-15",  # Saturday
+            "1952-03-22",  # Saturday
+            "1952-03-29",  # Saturday
+            "1952-04-05",  # Saturday
+            "1952-04-12",  # Saturday
+            "1952-04-19",  # Saturday
+            "1952-04-26",  # Saturday
+            "1952-05-03",  # Saturday
+            "1952-05-10",  # Saturday
+            "1952-05-17",  # Saturday
+            "1952-05-24",  # Saturday ## Last Trading Saturday. ##
+            "1952-05-29",  # Thursday
+            "1952-06-06",  # Friday
+            "1952-06-13",  # Friday
+            "1952-06-20",  # Friday
+            "1952-06-27",  # Friday       All Saturdays, and the
+            "1952-07-03",  # Thursday     two fridays, in this
+            "1952-07-11",  # Friday       range are omitted since
+            "1952-07-18",  # Friday       they are labeled as holidays.
+            "1952-07-25",  # Friday
+            "1952-08-01",  # Friday
+            "1952-08-08",  # Friday
+            "1952-08-15",  # Friday
+            "1952-08-22",  # Friday
+            "1952-08-29",  # Friday
+            "1952-09-05",  # Friday
+            "1952-09-12",  # Friday
+            "1952-09-19",  # Friday
+            "1952-09-26",  # Friday ## 1952-09-29 is Crossover ##
+            "1952-10-03",  # Friday
+            "1952-10-10",  # Friday
+            "1952-10-17",  # Friday
+            "1952-10-24",  # Friday
+            "1952-10-31",  # Friday
+            "1952-11-07",  # Friday
+            "1952-11-14",  # Friday
+            "1952-11-21",  # Friday
+            "1952-11-28",  # Friday
+            "1952-12-05",  # Friday
+            "1952-12-12",  # Friday
+            "1952-12-19",  # Friday
+            "1952-12-26",  # Friday
+        ],
+        dtype="datetime64[ns]",
+        freq=None,
+    )
+
+    # Ensure all three different ways produce the same range.
+    assert_index_equal(
+        actual_week_ends,
+        nyse.date_range_htf("1W", "1952-01-01", "1953-01-01", closed="right"),
+    )
+    assert_index_equal(
+        actual_week_ends,
+        nyse.date_range_htf("1W", "1952-01-01", periods=52, closed="right"),
+    )
+    assert_index_equal(
+        actual_week_ends,
+        nyse.date_range_htf("1W", end="1953-01-01", periods=52, closed="right"),
+    )
+
+    # Ensure all three different ways produce the same range.
+    assert_index_equal(
+        actual_week_ends[::3],
+        nyse.date_range_htf("3W", "1952-01-01", "1953-01-01", closed="right"),
+    )
+    assert_index_equal(
+        actual_week_ends[::3],
+        nyse.date_range_htf("3W", "1952-01-01", periods=18, closed="right"),
+    )
+    assert_index_equal(
+        actual_week_ends[::-1][::3][::-1],
+        nyse.date_range_htf("3W", end="1953-01-01", periods=18, closed="right"),
+    )
+    assert_index_equal(
+        actual_week_ends[::-1][::7][::-1],
+        nyse.date_range_htf("7W", end="1953-01-01", periods=8, closed="right"),
+    )
+
+    # Results Should Agree between the two methods in this critical range
+    actual_days = nyse.valid_days("1952-05-01", "1952-11-01").tz_localize(None)
+
+    assert_index_equal(
+        actual_days,
+        nyse.date_range_htf("D", "1952-05-01", "1952-11-01"),
+    )
+    assert_index_equal(
+        actual_days,
+        nyse.date_range_htf("D", "1952-05-01", periods=132),
+    )
+    assert_index_equal(
+        actual_days,
+        nyse.date_range_htf("D", end="1952-11-01", periods=132),
+    )
+
+    assert_index_equal(
+        actual_days[::3],
+        nyse.date_range_htf("3D", "1952-05-01", "1952-11-01"),
+    )
+    assert_index_equal(
+        actual_days[::3],
+        nyse.date_range_htf("3D", "1952-05-01", periods=44),
+    )
+    assert_index_equal(
+        actual_days[::-1][::3][::-1],
+        nyse.date_range_htf("3D", end="1952-11-01", periods=44),
+    )
+    assert_index_equal(
+        actual_days[::-1][::7][::-1],
+        nyse.date_range_htf("7D", end="1952-11-01", periods=19),
+    )
+
+
 def test_1953():
     start = "1953-01-01"
     end = "1953-12-31"


### PR DESCRIPTION
As Noted in the update log this PR brings the following:

- Added mark_session() Util Function
- Added MarketCalendar.date_range_htf() Method
- Added MarketCalendar.schedule_from_days() Method

The only thing of note that may not be backwards compatible with *every* user's implementation is the following change:
- Split NYSE Holiday Calendar into Two Calendars to support Date_Range_HTF()
  - NYSE.weekmask now returns "Mon Tue Wed Thur Fri" instead of "Mon Tue Wed Thur Fri Sat"

This was needed to make Date_Range_HTF() Work properly. In theory it should also make nyse schedule generation faster, but the difference is likely negligible. ** This doesn't effect the schedule. NYSE still produces Saturdays pre-1952, it just does so using a different implementation.

For Information on the features added see the updates to the Usage Notebook.
  - mark_session(): Helpers > Mark Session
  - MarketCalendar.date_range_htf(): Basic Usage > Exchange open valid business days: Date_Range_HTF()
  - MarketCalendar.schedule_from_days(): Basic Usage > Schedule_From_Days
  - date_range(): Helpers > date_range 
            - (These were actually updates in PR #358)
