### PR TITLE
Add full names for markets

### DIFF
--- a/pandas_market_calendars/calendars/asx.py
+++ b/pandas_market_calendars/calendars/asx.py
@@ -43,6 +43,10 @@ class ASXExchangeCalendar(MarketCalendar):
         return "ASX"
 
     @property
+    def full_name(self):
+        return "Australian Securities Exchange"
+
+    @property
     def tz(self):
         return timezone("Australia/Sydney")
 

--- a/pandas_market_calendars/calendars/bse.py
+++ b/pandas_market_calendars/calendars/bse.py
@@ -413,6 +413,10 @@ class BSEExchangeCalendar(MarketCalendar):
         return "BSE"
 
     @property
+    def full_name(self):
+        return "Bombay Stock Exchange"
+
+    @property
     def tz(self):
         return timezone("Asia/Calcutta")
 

--- a/pandas_market_calendars/calendars/cboe.py
+++ b/pandas_market_calendars/calendars/cboe.py
@@ -84,6 +84,10 @@ class CFEExchangeCalendar(MarketCalendar):
         return "CFE"
 
     @property
+    def full_name(self):
+        return "CBOE Futures Exchange"
+
+    @property
     def tz(self):
         return timezone("America/Chicago")
 

--- a/pandas_market_calendars/calendars/hkex.py
+++ b/pandas_market_calendars/calendars/hkex.py
@@ -382,6 +382,10 @@ class HKEXExchangeCalendar(MarketCalendar):
         return "HKEX"
 
     @property
+    def full_name(self):
+        return "Hong Kong Stock Exchange"
+
+    @property
     def tz(self):
         return timezone("Asia/Shanghai")
 

--- a/pandas_market_calendars/calendars/iex.py
+++ b/pandas_market_calendars/calendars/iex.py
@@ -55,6 +55,10 @@ class IEXExchangeCalendar(NYSEExchangeCalendar):
         return "IEX"
 
     @property
+    def full_name(self):
+        return "Investor's Exchange"
+
+    @property
     def weekmask(self):
         return "Mon Tue Wed Thu Fri"
 

--- a/pandas_market_calendars/calendars/jpx.py
+++ b/pandas_market_calendars/calendars/jpx.py
@@ -42,6 +42,10 @@ class JPXExchangeCalendar(MarketCalendar):
         return "JPX"
 
     @property
+    def full_name(self):
+        return "Japan Exchange Group"
+
+    @property
     def tz(self):
         return timezone("Asia/Tokyo")
 

--- a/pandas_market_calendars/calendars/lse.py
+++ b/pandas_market_calendars/calendars/lse.py
@@ -70,6 +70,10 @@ class LSEExchangeCalendar(MarketCalendar):
         return "LSE"
 
     @property
+    def full_name(self):
+        return "London Stock Exchange"
+
+    @property
     def tz(self):
         return timezone("Europe/London")
 

--- a/pandas_market_calendars/calendars/nyse.py
+++ b/pandas_market_calendars/calendars/nyse.py
@@ -828,6 +828,10 @@ class NYSEExchangeCalendar(MarketCalendar):
         return "NYSE"
 
     @property
+    def full_name(self):
+        return "New York Stock Exchange"
+
+    @property
     def tz(self):
         return timezone("America/New_York")
 

--- a/pandas_market_calendars/calendars/ose.py
+++ b/pandas_market_calendars/calendars/ose.py
@@ -84,6 +84,10 @@ class OSEExchangeCalendar(MarketCalendar):
         return "OSE"
 
     @property
+    def full_name(self):
+        return "Oslo Stock Exchange"
+
+    @property
     def tz(self):
         return timezone("Europe/Oslo")
 

--- a/pandas_market_calendars/calendars/sifma.py
+++ b/pandas_market_calendars/calendars/sifma.py
@@ -111,6 +111,10 @@ class SIFMAUSExchangeCalendar(MarketCalendar):
         return "SIFMA_US"
 
     @property
+    def full_name(self):
+        return "Securities Industry and Financial Markets Association"
+
+    @property
     def tz(self):
         return timezone("America/New_York")
 

--- a/pandas_market_calendars/calendars/six.py
+++ b/pandas_market_calendars/calendars/six.py
@@ -109,6 +109,10 @@ class SIXExchangeCalendar(MarketCalendar):
         return "SIX"
 
     @property
+    def full_name(self):
+        return "SIX Swiss Exchange"
+
+    @property
     def tz(self):
         return timezone("Europe/Zurich")
 

--- a/pandas_market_calendars/calendars/sse.py
+++ b/pandas_market_calendars/calendars/sse.py
@@ -30,6 +30,10 @@ class SSEExchangeCalendar(MarketCalendar):
         return "SSE"
 
     @property
+    def full_name(self):
+        return "Shanghai Stock Exchange"
+
+    @property
     def tz(self):
         return timezone("Asia/Shanghai")
 

--- a/pandas_market_calendars/calendars/tase.py
+++ b/pandas_market_calendars/calendars/tase.py
@@ -187,6 +187,10 @@ class TASEExchangeCalendar(MarketCalendar):
         return "TASE"
 
     @property
+    def full_name(self):
+        return "Tel Aviv Stock Exchange"
+
+    @property
     def tz(self):
         return timezone("Asia/Jerusalem")
 

--- a/pandas_market_calendars/calendars/tsx.py
+++ b/pandas_market_calendars/calendars/tsx.py
@@ -139,6 +139,10 @@ class TSXExchangeCalendar(MarketCalendar):
         return "TSX"
 
     @property
+    def full_name(self):
+        return "Toronto Stock Exchange"
+
+    @property
     def tz(self):
         return timezone("Canada/Eastern")
 

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -138,6 +138,16 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
     @property
     @abstractmethod
+    def full_name(self):
+        """
+        Full name of the market
+
+        :return: string name
+        """
+        return self.name
+
+    @property
+    @abstractmethod
     def tz(self):
         """
         Time zone for the market.


### PR DESCRIPTION
Added a new property `full_name` to the `MarketCalendar`.

Added the full names for market abbreviations I could find a proper name for.

Fixes #378.