### PR TITLE
A non-functional attempt at fixing #387

### DIFF
--- a/pandas_market_calendars/calendars/nyse.py
+++ b/pandas_market_calendars/calendars/nyse.py
@@ -1141,19 +1141,12 @@ class NYSEExchangeCalendar(MarketCalendar):
             (
                 time(13, tzinfo=ZoneInfo("America/New_York")),
                 # DaysBeforeIndependenceDay1pmEarlyCloseAdhoc # list
-                ChristmasEve1pmEarlyCloseAdhoc
-                + DayAfterChristmas1pmEarlyCloseAdhoc
-                + BacklogRelief1pmEarlyClose1929,
+                ChristmasEve1pmEarlyCloseAdhoc + DayAfterChristmas1pmEarlyCloseAdhoc + BacklogRelief1pmEarlyClose1929,
             ),
             (
                 time(14, tzinfo=ZoneInfo("America/New_York")),
                 _union_many(
-                    [
-                        pd.DatetimeIndex(
-                            ChristmasEve2pmEarlyCloseAdhoc
-                            + HeavyVolume2pmEarlyClose1933
-                        )
-                    ]
+                    [pd.DatetimeIndex(ChristmasEve2pmEarlyCloseAdhoc + HeavyVolume2pmEarlyClose1933)]
                     + [
                         BacklogRelief2pmEarlyClose1928,
                         TransitStrike2pmEarlyClose1966,  # index
@@ -1166,15 +1159,11 @@ class NYSEExchangeCalendar(MarketCalendar):
             ),
             (
                 time(14, 30, tzinfo=ZoneInfo("America/New_York")),
-                _union_many(
-                    [PaperworkCrisis230pmEarlyCloses1969, Backlog230pmEarlyCloses1987]
-                ),  # index
+                _union_many([PaperworkCrisis230pmEarlyCloses1969, Backlog230pmEarlyCloses1987]),  # index
             ),
             (
                 time(15, tzinfo=ZoneInfo("America/New_York")),
-                _union_many(
-                    [PaperworkCrisis3pmEarlyCloses1969to1970, Backlog3pmEarlyCloses1987]
-                ),  # index
+                _union_many([PaperworkCrisis3pmEarlyCloses1969to1970, Backlog3pmEarlyCloses1987]),  # index
             ),
             (
                 time(15, 30, tzinfo=ZoneInfo("America/New_York")),

--- a/pandas_market_calendars/calendars/nyse.py
+++ b/pandas_market_calendars/calendars/nyse.py
@@ -818,7 +818,10 @@ class NYSEExchangeCalendar(MarketCalendar):
             ("1952-09-29", time(15, 30)),
             ("1974-01-01", time(16)),
         ),
-        "post": ((None, time(20)),),
+        "post": (
+            (None, time(20)),
+            ("1999-01-01", time(17)),  # Adjust post-market close for early close days
+        ),
     }
 
     _saturday_close = time(12)
@@ -1111,6 +1114,15 @@ class NYSEExchangeCalendar(MarketCalendar):
                 AbstractHolidayCalendar(
                     rules=[
                         SystemProb356pmEarlyClose2005,
+                    ]
+                ),
+            ),
+            (
+                time(17, tzinfo=ZoneInfo("America/New_York")),
+                AbstractHolidayCalendar(
+                    rules=[
+                        ChristmasEvePost1999Early1pmClose,
+                        DayAfterThanksgiving1pmEarlyCloseInOrAfter1993,
                     ]
                 ),
             ),

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -782,6 +782,11 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
                     elif market_time == "market_close":
                         _close_adj = specialix
 
+            if market_time == "post":
+                special = self.special_dates(market_time, days[0], days[-1], filter_holidays=False)
+                specialix = special.index[special.index.isin(temp.index)]
+                temp.loc[specialix] = special
+
             schedule[market_time] = temp
 
         cols = schedule.columns

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -436,6 +436,34 @@ def test_juneteenth():
     assert pd.Timestamp("6/19/2023", tz="UTC") not in good_dates
 
 
+def test_christmas_eve_post_market_close():
+    from pandas_market_calendars.calendars.nyse import NYSEExchangeCalendar
+    import pandas as pd
+
+    nyse = NYSEExchangeCalendar()
+    schedule = nyse.schedule(
+        start_date="2019-12-24", end_date="2019-12-24", market_times=["market_open", "market_close", "post"]
+    )
+
+    assert schedule.loc["2019-12-24", "market_close"] == pd.Timestamp(
+        "2019-12-24 13:00:00-05:00", tz="America/New_York"
+    )
+    assert schedule.loc["2019-12-24", "post"] == pd.Timestamp(
+        "2019-12-24 17:00:00-05:00", tz="America/New_York"
+    )
+
+    schedule_2025 = nyse.schedule(
+        start_date="2025-12-24", end_date="2025-12-24", market_times=["market_open", "market_close", "post"]
+    )
+
+    assert schedule_2025.loc["2025-12-24", "market_close"] == pd.Timestamp(
+        "2025-12-24 13:00:00-05:00", tz="America/New_York"
+    )
+    assert schedule_2025.loc["2025-12-24", "post"] == pd.Timestamp(
+        "2025-12-24 17:00:00-05:00", tz="America/New_York"
+    )
+
+
 if __name__ == "__main__":
     print("runing open")
     test_days_at_time_open()


### PR DESCRIPTION
GitHub Copilot's attempt at fixing https://github.com/rsheftel/pandas_market_calendars/issues/387

It fails so obviously not an actual fix.  I was so hopeful as it was chugging along but it got stuck on this failure:
```
FAILED tests/test_nyse_calendar.py::test_christmas_eve_post_market_close - AssertionError: assert Timestamp('2019-12-24 18:00:00+0000', tz='UTC') == Timestamp('2019-12-24 17:00:00-0500', tz='America/New_York')
```

But I assume it also causes these too:
```
FAILED tests/test_nyse_calendar.py::test_day_after_thanksgiving - AssertionError: assert Timestamp('2012-11-23 15:00:00-0500', tz='America/New_York') > Timestamp('2012-11-23 22:00:00+0000', tz='UTC')
FAILED tests/test_nyse_calendar_early_years.py::test_1999 - ValueError: cannot reindex on an axis with duplicate labels
FAILED tests/test_utils.py::test_mark_session_edge_case - AssertionError: Series are different
```

So just sharing in case it is at all helpful. I have to use an ugly hack in my application for now but I'll come back to this later.
