### PR TITLE
Better merge_schedules outer join handling

### DIFF
--- a/pandas_market_calendars/calendar_utils.py
+++ b/pandas_market_calendars/calendar_utils.py
@@ -161,11 +161,11 @@ def merge_schedules(schedules, how="outer"):
     for schedule in schedules[1:]:
         result = result.merge(schedule, how=how, right_index=True, left_index=True)
         if how == "outer":
-            result["market_open"] = result.apply(lambda x: min(x.market_open_x, x.market_open_y), axis=1)
-            result["market_close"] = result.apply(lambda x: max(x.market_close_x, x.market_close_y), axis=1)
+            result["market_open"] = result[["market_open_x", "market_open_y"]].min(axis=1)
+            result["market_close"] = result[["market_close_x", "market_close_y"]].max(axis=1)
         elif how == "inner":
-            result["market_open"] = result.apply(lambda x: max(x.market_open_x, x.market_open_y), axis=1)
-            result["market_close"] = result.apply(lambda x: min(x.market_close_x, x.market_close_y), axis=1)
+            result["market_open"] = result[["market_open_x", "market_open_y"]].max(axis=1)
+            result["market_close"] = result[["market_close_x", "market_close_y"]].min(axis=1)
         else:
             raise ValueError('how argument must be "inner" or "outer"')
         result = result[["market_open", "market_close"]]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,6 +61,10 @@ def test_merge_schedules():
     actual = mcal.merge_schedules([sch1, sch2], how="outer")
     assert_frame_equal(actual, expected)
 
+    # reverse should also work
+    actual = mcal.merge_schedules([sch2, sch1], how="outer")
+    assert_frame_equal(actual, expected)
+
     # inner join will exclude July 4th because not open for both
     expected = pd.DataFrame(
         {


### PR DESCRIPTION
The existing behavior will inconsistently insert NaT for the open/close time based on the order of the schedules.