### PR TITLE
Added Chinese holidays for 2026

### DIFF
--- a/pandas_market_calendars/calendars/sse.py
+++ b/pandas_market_calendars/calendars/sse.py
@@ -54,7 +54,7 @@ class SSEExchangeCalendar(MarketCalendar):
         # Since all past holidays are adhoc, start_year should always be a year in the future.
         # For example: Holiday arrangements for 2022 are now included,
         # then our guesswork starts from the next year so start_year = 2023
-        start_year = 2026
+        start_year = 2027
 
         return AbstractHolidayCalendar(
             rules=[

--- a/pandas_market_calendars/holidays/cn.py
+++ b/pandas_market_calendars/holidays/cn.py
@@ -604,6 +604,26 @@ all_holidays = [
     Timestamp("2025-10-06"),
     Timestamp("2025-10-07"),
     Timestamp("2025-10-08"),
+    # 2026 holidays
+    Timestamp("2026-01-01"),  # New Year
+    Timestamp("2026-01-02"),
+    Timestamp("2026-02-16"),  # Spring Festival
+    Timestamp("2026-02-17"),
+    Timestamp("2026-02-18"),
+    Timestamp("2026-02-19"),
+    Timestamp("2026-02-20"),
+    Timestamp("2026-02-23"),
+    Timestamp("2026-04-06"),  # Tomb-sweeping Day
+    Timestamp("2026-05-01"),  # Labor Day
+    Timestamp("2026-05-04"),
+    Timestamp("2026-05-05"),
+    Timestamp("2026-06-19"),  # Dragon Boat Festival
+    Timestamp("2026-09-25"),  # Mid-autumn Festival
+    Timestamp("2026-10-01"),  # National Day
+    Timestamp("2026-10-02"),
+    Timestamp("2026-10-05"),
+    Timestamp("2026-10-06"),
+    Timestamp("2026-10-07"),
 ]
 
 # The following holidays are based on Solar terms or Chinese lunisolar calendar,


### PR DESCRIPTION
Updated Chinese holidays for 2026 based on latest state council announcement: https://www.gov.cn/zhengce/content/202511/content_7047090.htm