### PR TITLE
Align CME_Equity Good Friday handling with CME Globex equity early closes

### DIFF
--- a/pandas_market_calendars/calendars/cme.py
+++ b/pandas_market_calendars/calendars/cme.py
@@ -27,6 +27,13 @@ from pandas.tseries.holiday import (
 from zoneinfo import ZoneInfo
 
 from pandas_market_calendars.holidays.cme import (
+    GoodFriday2010,
+    GoodFriday2012,
+    GoodFriday2015,
+    GoodFriday2021,
+    GoodFriday2022,
+    GoodFridayAfter2022,
+    GoodFridayBefore2021NotEarlyClose,
     USIndependenceDayBefore2022PreviousDay,
 )
 from pandas_market_calendars.holidays.us import (
@@ -129,7 +136,8 @@ class CMEEquityExchangeCalendar(MarketCalendar):
         return AbstractHolidayCalendar(
             rules=[
                 USNewYearsDay,
-                GoodFriday,
+                GoodFridayBefore2021NotEarlyClose,
+                GoodFriday2022,
                 Christmas,
             ]
         )
@@ -141,6 +149,18 @@ class CMEEquityExchangeCalendar(MarketCalendar):
     @property
     def special_closes(self):
         return [
+            (
+                time(8, 15),
+                AbstractHolidayCalendar(
+                    rules=[
+                        GoodFriday2010,
+                        GoodFriday2012,
+                        GoodFriday2015,
+                        GoodFriday2021,
+                        GoodFridayAfter2022,
+                    ]
+                ),
+            ),
             (
                 time(12),
                 AbstractHolidayCalendar(

--- a/tests/test_cme_equity_calendar.py
+++ b/tests/test_cme_equity_calendar.py
@@ -58,3 +58,12 @@ def test_dec_jan():
 
     assert schedule["market_open"].iloc[0] == pd.Timestamp("2016-12-29 23:00:00", tz="UTC")
     assert schedule["market_close"].iloc[6] == pd.Timestamp("2017-01-10 22:00:00", tz="UTC")
+
+
+def test_good_friday_2026_has_early_close_session():
+    cme = CMEEquityExchangeCalendar()
+    schedule = cme.schedule("2026-04-01", "2026-04-07", tz="America/New_York")
+
+    session = schedule.loc["2026-04-03"]
+    assert session.market_open == pd.Timestamp("2026-04-02 18:00:00", tz="America/New_York")
+    assert session.market_close == pd.Timestamp("2026-04-03 09:15:00", tz="America/New_York")


### PR DESCRIPTION
## Summary
- align  Good Friday handling with the existing  schedule exceptions
- treat post-2022 Good Friday as an early-close session instead of a full holiday
- add a regression test for the 2026-04-03 session window

## Validation
- ......                                                                   [100%]
6 passed in 0.25s
