### PR TITLE
Fix market calendar issue cluster

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,13 @@ have different market open, closes, breaks and holidays based on product type.
 
 This package provides access to over 50+ unique exchange calendars for global equity and futures markets.
 
+Calendar Data and Updates
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Calendars and their rules are shipped as package code. pandas_market_calendars does not request market hours from a
+server at runtime. To receive corrected or updated market hours, install a newer package release or update the source
+code. Calendars mirrored from ``exchange_calendars`` likewise use the version installed in the local Python environment,
+not a live data feed.
+
 This package is a fork of the Zipline package from Quantopian and extracts just the relevant parts. All credit for
 their excellent work to Quantopian.
 

--- a/docs/calendars.rst
+++ b/docs/calendars.rst
@@ -36,6 +36,7 @@ CME        CME_Agriculture    CMEAgriculturalExchangeCalendar     Yes         li
 CME        CME Globex Crypto  CMEGlobexCryptoExchangeCalendar     Yes         Coinbase Asset Management
 CME        CMEGlobex_Grains   CMEGlobexGrainsExchangeCalendar     Yes         rundef
 EUREX      EUREX_Bond         EUREXFixedIncomeCalendar            Yes         rundef
+EUREX      EUREX_PrePost      EUREXPrePostExchangeCalendar       Yes         rsheftel
 ========== ================= =================================== ============ ============
 
 Forex/OTC Market Calendars

--- a/docs/calendars.rst
+++ b/docs/calendars.rst
@@ -21,7 +21,8 @@ Exchange  SSE    SSEExchangeCalendar     Yes        keli
 Exchange  TASE   TASEExchangeCalendar               gabglus
 Exchange  HKEX   HKEXExchangeCalendar    Yes        1dot75cm
 Exchange  ASX    ASXExchangeCalendar                pulledlamb
-Exchange  BSE    BSEExchangeCalendar                rakesh1988
+Exchange  BSE    BSEExchangeCalendar     Yes        rakesh1988
+Exchange  NSE    NSEExchangeCalendar     Yes        rakesh1988
 Exchange  IEX    IEXExchangeCalendar     Yes        carterjfulcher
 ========= ====== ===================== ============ ==========
 

--- a/pandas_market_calendars/calendar_registry.py
+++ b/pandas_market_calendars/calendar_registry.py
@@ -5,7 +5,7 @@ import datetime
 from .market_calendar import MarketCalendar
 from .calendars.asx import ASXExchangeCalendar
 from .calendars.bmf import BMFExchangeCalendar
-from .calendars.bse import BSEExchangeCalendar
+from .calendars.bse import BSEExchangeCalendar, NSEExchangeCalendar
 from .calendars.cboe import CFEExchangeCalendar
 from .calendars.cme import (
     CMEEquityExchangeCalendar, CMEBondExchangeCalendar, CMETradeDateCalendar

--- a/pandas_market_calendars/calendar_utils.py
+++ b/pandas_market_calendars/calendar_utils.py
@@ -170,6 +170,7 @@ def merge_schedules(schedules: List[pd.DataFrame], how: Literal["outer", "inner"
         elif how == "inner":
             result["market_open"] = result[["market_open_x", "market_open_y"]].max(axis=1)
             result["market_close"] = result[["market_close_x", "market_close_y"]].min(axis=1)
+            result = result[result["market_open"] < result["market_close"]]
         else:
             raise ValueError('how argument must be "inner" or "outer"')
         result = result[["market_open", "market_close"]]

--- a/pandas_market_calendars/calendars/asx.py
+++ b/pandas_market_calendars/calendars/asx.py
@@ -4,10 +4,7 @@ from pandas.tseries.holiday import AbstractHolidayCalendar, EasterMonday, GoodFr
 from zoneinfo import ZoneInfo
 
 from pandas_market_calendars.holidays.oz import *
-from pandas_market_calendars.market_calendar import MarketCalendar
-
-
-AbstractHolidayCalendar.start_date = "2011-01-01"
+from pandas_market_calendars.market_calendar import HolidayCalendar, MarketCalendar
 
 
 class ASXExchangeCalendar(MarketCalendar):
@@ -54,7 +51,8 @@ class ASXExchangeCalendar(MarketCalendar):
 
     @property
     def regular_holidays(self):
-        return AbstractHolidayCalendar(
+        return HolidayCalendar(
+            start_date="2011-01-01",
             rules=[
                 OZNewYearsDay,
                 AustraliaDay,
@@ -64,7 +62,7 @@ class ASXExchangeCalendar(MarketCalendar):
                 BoxingDay,
                 GoodFriday,
                 EasterMonday,
-            ]
+            ],
         )
 
     @property

--- a/pandas_market_calendars/calendars/bse.py
+++ b/pandas_market_calendars/calendars/bse.py
@@ -421,7 +421,9 @@ BSEClosedDay = [
     Timestamp("2026-12-25", tz="UTC"),  # Fri, Christmas
 ]
 
-NSEClosedDay = BSEClosedDay.copy()
+# BSE and NSE currently share the same published closure set in this module.
+# Keep this as a shared object so future exchange-specific deltas are explicit.
+NSEClosedDay = BSEClosedDay
 
 
 class BSEExchangeCalendar(MarketCalendar):
@@ -435,7 +437,7 @@ class BSEExchangeCalendar(MarketCalendar):
     early closes or late opens.
     """
 
-    aliases = ["BSE"]
+    aliases = ["BSE", "XBOM"]
     regular_market_times = {
         "market_open": ((None, time(9, 15)),),
         "market_close": ((None, time(15, 30)),),

--- a/pandas_market_calendars/calendars/bse.py
+++ b/pandas_market_calendars/calendars/bse.py
@@ -426,7 +426,7 @@ NSEClosedDay = BSEClosedDay.copy()
 
 class BSEExchangeCalendar(MarketCalendar):
     """
-    Exchange calendar for the Bombay Stock Exchange (BSE, XBOM).
+    Exchange calendar for the Bombay Stock Exchange (BSE).
     Open Time: 9:15 AM, Asia/Calcutta
     Close Time: 3:30 PM, Asia/Calcutta
 
@@ -435,7 +435,7 @@ class BSEExchangeCalendar(MarketCalendar):
     early closes or late opens.
     """
 
-    aliases = ["BSE", "XBOM"]
+    aliases = ["BSE"]
     regular_market_times = {
         "market_open": ((None, time(9, 15)),),
         "market_close": ((None, time(15, 30)),),

--- a/pandas_market_calendars/calendars/bse.py
+++ b/pandas_market_calendars/calendars/bse.py
@@ -382,6 +382,7 @@ BSEClosedDay = [
     Timestamp("2024-04-11", tz="UTC"),  # Thu, Id-Ul-Fitr (Ramadan Eid)
     Timestamp("2024-04-17", tz="UTC"),  # Wed, Shri Ram Navmi
     Timestamp("2024-05-01", tz="UTC"),  # Wed, Maharashtra Din
+    Timestamp("2024-05-20", tz="UTC"),  # Mon, General Parliamentary Elections
     Timestamp("2024-06-17", tz="UTC"),  # Mon, Bakri Id / Eid ul-Adha
     Timestamp("2024-07-17", tz="UTC"),  # Wed, Moharram
     Timestamp("2024-08-15", tz="UTC"),  # Thu, Independence Day
@@ -420,6 +421,8 @@ BSEClosedDay = [
     Timestamp("2026-12-25", tz="UTC"),  # Fri, Christmas
 ]
 
+NSEClosedDay = BSEClosedDay.copy()
+
 
 class BSEExchangeCalendar(MarketCalendar):
     """
@@ -428,11 +431,11 @@ class BSEExchangeCalendar(MarketCalendar):
     Close Time: 3:30 PM, Asia/Calcutta
 
     Due to the complexity around the BSE holidays, we are hardcoding a list
-    of holidays back to 1997, and forward through 2020.  There are no known
+    of holidays back to 1997, and forward through 2026.  There are no known
     early closes or late opens.
     """
 
-    aliases = ["BSE", "NSE", "XNSE"]
+    aliases = ["BSE", "XBOM"]
     regular_market_times = {
         "market_open": ((None, time(9, 15)),),
         "market_close": ((None, time(15, 30)),),
@@ -453,3 +456,23 @@ class BSEExchangeCalendar(MarketCalendar):
     @property
     def adhoc_holidays(self):
         return BSEClosedDay
+
+
+class NSEExchangeCalendar(BSEExchangeCalendar):
+    """
+    Exchange calendar for the National Stock Exchange of India (NSE, XNSE).
+    """
+
+    aliases = ["NSE", "XNSE"]
+
+    @property
+    def name(self):
+        return "NSE"
+
+    @property
+    def full_name(self):
+        return "National Stock Exchange of India"
+
+    @property
+    def adhoc_holidays(self):
+        return NSEClosedDay

--- a/pandas_market_calendars/calendars/cme.py
+++ b/pandas_market_calendars/calendars/cme.py
@@ -65,11 +65,13 @@ class CMETradeDateCalendar(MarketCalendar):
     that the markets are open on other days, so the opening hours for this are not
     meaningful (and hence are fixed to 5pm Central T-1 -> 4pm Central T)
     """
+
     aliases = ["CME_TradeDate"]
     regular_market_times = {
         "market_open": ((None, time(17), -1),),  # offset by -1 day
         "market_close": ((None, time(16)),),
     }
+
     @property
     def name(self):
         return "CME_TradeDate"
@@ -95,7 +97,6 @@ class CMETradeDateCalendar(MarketCalendar):
             ]
         )
 
-    
     @property
     def adhoc_holidays(self):
         # FIXME: This is unverified currently.
@@ -105,21 +106,34 @@ class CMETradeDateCalendar(MarketCalendar):
     def special_closes(self):
         return []
 
+
 class CMEEquityExchangeCalendar(MarketCalendar):
     """
     Exchange calendar for CME for Equity products
 
-    Open Time: 6:00 PM, America/New_York / 5:00 PM Chicago
-    Close Time: 5:00 PM, America/New_York / 4:00 PM Chicago
-    Break: 4:15 - 4:30pm America/New_York / 3:15 - 3:30 PM Chicago
+    Open Time: 5:00 PM, America/Chicago
+    Close Time: 4:00 PM, America/Chicago
+    Break: 3:15 - 3:30pm America/Chicago
     """
 
     aliases = ["CME_Equity", "CBOT_Equity"]
     regular_market_times = {
-        "market_open": ((None, time(17), -1),),  # offset by -1 day
-        "market_close": ((None, time(16)),),
+        "market_open": (
+            (None, time(17), -1),
+            ("2005-09-12", time(15, 30), -1),
+            ("2012-11-19", time(17), -1),
+        ),
+        "market_close": (
+            (None, time(16)),
+            ("2005-09-12", time(15, 15)),
+            ("2012-11-19", time(16)),
+        ),
         "break_start": ((None, time(15, 15)),),
-        "break_end": ((None, time(15, 30)),),
+        "break_end": (
+            (None, time(15, 30)),
+            ("2005-09-12", time(15, 15)),
+            ("2012-11-19", time(15, 30)),
+        ),
     }
 
     @property
@@ -178,7 +192,7 @@ class CMEEquityExchangeCalendar(MarketCalendar):
                         ChristmasEveInOrAfter1993,
                     ]
                 ),
-            )
+            ),
         ]
 
 
@@ -186,8 +200,8 @@ class CMEAgricultureExchangeCalendar(MarketCalendar):
     """
     Exchange calendar for CME for Agriculture products
 
-    Open Time: 5:00 PM, America/Chicago
-    Close Time: 5:00 PM, America/Chicago
+    Open Time: 7:00 PM, America/Chicago
+    Close Time: 1:20 PM, America/Chicago
 
     Regularly-Observed Holidays:
     - New Years Day
@@ -202,8 +216,10 @@ class CMEAgricultureExchangeCalendar(MarketCalendar):
         "NYMEX_Agriculture",
     ]
     regular_market_times = {
-        "market_open": ((None, time(17, 1), -1),),  # offset by -1 day
-        "market_close": ((None, time(17)),),
+        "market_open": ((None, time(19), -1),),
+        "market_close": ((None, time(13, 20)),),
+        "break_start": ((None, time(7, 45)),),
+        "break_end": ((None, time(8, 30)),),
     }
 
     @property

--- a/pandas_market_calendars/calendars/cme.py
+++ b/pandas_market_calendars/calendars/cme.py
@@ -26,7 +26,7 @@ from pandas.tseries.holiday import (
 )
 from zoneinfo import ZoneInfo
 
-from pandas_market_calendars.calendars.cme_globex_agriculture import GRAINS_AND_OILSEEDS_MARKET_TIMES
+from pandas_market_calendars.calendars.cme_market_times import GRAINS_AND_OILSEEDS_MARKET_TIMES
 from pandas_market_calendars.holidays.cme import (
     GoodFriday2010,
     GoodFriday2012,
@@ -57,6 +57,9 @@ from pandas_market_calendars.market_calendar import MarketCalendar
 # For example, http://www.cmegroup.com/tools-information/holiday-calendar/files/2016-4th-of-july-holiday-schedule.pdf
 # shows that Equity, Interest Rate, FX, Energy, Metals & DME Products close at 1200 CT on July 4, 2016, while Grain,
 # Oilseed & MGEX Products and Livestock, Dairy & Lumber products are completely closed.
+
+CME_EQUITY_LEGACY_HOURS_START = "2005-09-12"
+CME_EQUITY_MODERN_HOURS_START = "2012-11-19"
 
 
 class CMETradeDateCalendar(MarketCalendar):
@@ -118,22 +121,26 @@ class CMEEquityExchangeCalendar(MarketCalendar):
     """
 
     aliases = ["CME_Equity", "CBOT_Equity"]
+    # CME shortened its equity trading session between the 2005 Globex
+    # migration and the 2012 hours change.  The base calendar cannot model a
+    # temporary absence of a break, so that era is represented as a zero-length
+    # 15:15 break that coincides with the close.
     regular_market_times = {
         "market_open": (
             (None, time(17), -1),
-            ("2005-09-12", time(15, 30), -1),
-            ("2012-11-19", time(17), -1),
+            (CME_EQUITY_LEGACY_HOURS_START, time(15, 30), -1),
+            (CME_EQUITY_MODERN_HOURS_START, time(17), -1),
         ),
         "market_close": (
             (None, time(16)),
-            ("2005-09-12", time(15, 15)),
-            ("2012-11-19", time(16)),
+            (CME_EQUITY_LEGACY_HOURS_START, time(15, 15)),
+            (CME_EQUITY_MODERN_HOURS_START, time(16)),
         ),
         "break_start": ((None, time(15, 15)),),
         "break_end": (
             (None, time(15, 30)),
-            ("2005-09-12", time(15, 15)),
-            ("2012-11-19", time(15, 30)),
+            (CME_EQUITY_LEGACY_HOURS_START, time(15, 15)),
+            (CME_EQUITY_MODERN_HOURS_START, time(15, 30)),
         ),
     }
 
@@ -144,7 +151,6 @@ class CMEEquityExchangeCalendar(MarketCalendar):
     @property
     def tz(self):
         return ZoneInfo("America/Chicago")
-
 
     @property
     def regular_holidays(self):

--- a/pandas_market_calendars/calendars/cme.py
+++ b/pandas_market_calendars/calendars/cme.py
@@ -144,6 +144,22 @@ class CMEEquityExchangeCalendar(MarketCalendar):
     def tz(self):
         return ZoneInfo("America/Chicago")
 
+    def _trade_date_calendar(self):
+        try:
+            return self._cme_trade_date_calendar
+        except AttributeError:
+            self._cme_trade_date_calendar = CMETradeDateCalendar()
+            return self._cme_trade_date_calendar
+
+    def valid_days(self, start_date, end_date, tz="UTC"):
+        return self._trade_date_calendar().valid_days(start_date, end_date, tz=tz)
+
+    def _valid_days_for_schedule(self, start_date, end_date, tz="UTC"):
+        return MarketCalendar.valid_days(self, start_date, end_date, tz=tz)
+
+    def _valid_days_for_special_times(self, start_date, end_date, tz="UTC"):
+        return MarketCalendar.valid_days(self, start_date, end_date, tz=tz)
+
     @property
     def regular_holidays(self):
         # Many days that are holidays for the NYSE are an early close day for CME

--- a/pandas_market_calendars/calendars/cme.py
+++ b/pandas_market_calendars/calendars/cme.py
@@ -26,6 +26,7 @@ from pandas.tseries.holiday import (
 )
 from zoneinfo import ZoneInfo
 
+from pandas_market_calendars.calendars.cme_globex_agriculture import GRAINS_AND_OILSEEDS_MARKET_TIMES
 from pandas_market_calendars.holidays.cme import (
     GoodFriday2010,
     GoodFriday2012,
@@ -144,21 +145,6 @@ class CMEEquityExchangeCalendar(MarketCalendar):
     def tz(self):
         return ZoneInfo("America/Chicago")
 
-    def _trade_date_calendar(self):
-        try:
-            return self._cme_trade_date_calendar
-        except AttributeError:
-            self._cme_trade_date_calendar = CMETradeDateCalendar()
-            return self._cme_trade_date_calendar
-
-    def valid_days(self, start_date, end_date, tz="UTC"):
-        return self._trade_date_calendar().valid_days(start_date, end_date, tz=tz)
-
-    def _valid_days_for_schedule(self, start_date, end_date, tz="UTC"):
-        return MarketCalendar.valid_days(self, start_date, end_date, tz=tz)
-
-    def _valid_days_for_special_times(self, start_date, end_date, tz="UTC"):
-        return MarketCalendar.valid_days(self, start_date, end_date, tz=tz)
 
     @property
     def regular_holidays(self):
@@ -231,12 +217,7 @@ class CMEAgricultureExchangeCalendar(MarketCalendar):
         "COMEX_Agriculture",
         "NYMEX_Agriculture",
     ]
-    regular_market_times = {
-        "market_open": ((None, time(19), -1),),
-        "market_close": ((None, time(13, 20)),),
-        "break_start": ((None, time(7, 45)),),
-        "break_end": ((None, time(8, 30)),),
-    }
+    regular_market_times = GRAINS_AND_OILSEEDS_MARKET_TIMES
 
     @property
     def name(self):

--- a/pandas_market_calendars/calendars/cme_globex_agriculture.py
+++ b/pandas_market_calendars/calendars/cme_globex_agriculture.py
@@ -38,6 +38,15 @@ from pandas_market_calendars.holidays.us import (
 from .cme_globex_base import CMEGlobexBaseExchangeCalendar
 
 
+GRAINS_AND_OILSEEDS_MARKET_TIMES = {
+    "market_open": ((None, time(19), -1),),  # offset by -1 day
+    "market_close": ((None, time(13, 20)),),
+    "break_start": ((None, time(7, 45)),),
+    "break_end": ((None, time(8, 30)),),
+}
+
+
+
 class CMEGlobexAgricultureExchangeCalendar(CMEGlobexBaseExchangeCalendar):
     """
     Exchange calendar for CME for Agriculture products
@@ -145,12 +154,7 @@ class CMEGlobexGrainsAndOilseedsExchangeCalendar(CMEGlobexAgricultureExchangeCal
         "CMEGlobex_Oilseeds",
     ]
 
-    regular_market_times = {
-        "market_open": ((None, time(19), -1),),  # offset by -1 day
-        "market_close": ((None, time(13, 20)),),
-        "break_start": ((None, time(7, 45)),),
-        "break_end": ((None, time(8, 30)),),
-    }
+    regular_market_times = GRAINS_AND_OILSEEDS_MARKET_TIMES
 
     @property
     def name(self):

--- a/pandas_market_calendars/calendars/cme_globex_agriculture.py
+++ b/pandas_market_calendars/calendars/cme_globex_agriculture.py
@@ -24,6 +24,7 @@ from pandas.tseries.holiday import (
     USThanksgivingDay,
 )
 
+from pandas_market_calendars.calendars.cme_market_times import GRAINS_AND_OILSEEDS_MARKET_TIMES
 from pandas_market_calendars.holidays.us import (
     Christmas,
     ChristmasEveBefore1993,
@@ -36,15 +37,6 @@ from pandas_market_calendars.holidays.us import (
 )
 
 from .cme_globex_base import CMEGlobexBaseExchangeCalendar
-
-
-GRAINS_AND_OILSEEDS_MARKET_TIMES = {
-    "market_open": ((None, time(19), -1),),  # offset by -1 day
-    "market_close": ((None, time(13, 20)),),
-    "break_start": ((None, time(7, 45)),),
-    "break_end": ((None, time(8, 30)),),
-}
-
 
 
 class CMEGlobexAgricultureExchangeCalendar(CMEGlobexBaseExchangeCalendar):

--- a/pandas_market_calendars/calendars/cme_globex_energy_and_metals.py
+++ b/pandas_market_calendars/calendars/cme_globex_energy_and_metals.py
@@ -219,3 +219,12 @@ class CMEGlobexEnergyAndMetalsExchangeCalendar(CMEGlobexBaseExchangeCalendar):
                 ),
             ),
         ]
+
+    @property
+    def special_closes_adhoc(self):
+        return [
+            (
+                time(15, 15),
+                ["2010-12-31"],
+            )
+        ]

--- a/pandas_market_calendars/calendars/cme_globex_fixed_income.py
+++ b/pandas_market_calendars/calendars/cme_globex_fixed_income.py
@@ -43,8 +43,8 @@ class CMEGlobexFixedIncomeCalendar(CMEGlobexBaseExchangeCalendar):
     aliases = ["CME Globex Fixed Income", "CME Globex Interest Rate Products"]
 
     regular_market_times = {
-        "market_open": ((None, time(18), -1),),
-        "market_close": ((None, time(17)),),
+        "market_open": ((None, time(17), -1),),
+        "market_close": ((None, time(16)),),
     }
 
     """
@@ -52,7 +52,6 @@ class CMEGlobexFixedIncomeCalendar(CMEGlobexBaseExchangeCalendar):
         Christmas/New_Years
             5am special open for a couple years (see tests)
 
-        regular market_open/market_close changed from 17/16 to 18/17?
     """
 
     @property

--- a/pandas_market_calendars/calendars/cme_market_times.py
+++ b/pandas_market_calendars/calendars/cme_market_times.py
@@ -1,0 +1,9 @@
+from datetime import time
+
+
+GRAINS_AND_OILSEEDS_MARKET_TIMES = {
+    "market_open": ((None, time(19), -1),),  # offset by -1 day
+    "market_close": ((None, time(13, 20)),),
+    "break_start": ((None, time(7, 45)),),
+    "break_end": ((None, time(8, 30)),),
+}

--- a/pandas_market_calendars/calendars/eurex.py
+++ b/pandas_market_calendars/calendars/eurex.py
@@ -90,8 +90,9 @@ class EUREXExchangeCalendar(MarketCalendar):
 
     aliases = ["EUREX"]
     regular_market_times = {
-        "market_open": ((None, time(9)),),
-        "market_close": ((None, time(17, 30)),),
+        "pre": ((None, time(1)),),
+        "market_open": ((None, time(8)),),
+        "market_close": ((None, time(22)),),
     }
 
     @property

--- a/pandas_market_calendars/calendars/eurex.py
+++ b/pandas_market_calendars/calendars/eurex.py
@@ -90,7 +90,6 @@ class EUREXExchangeCalendar(MarketCalendar):
 
     aliases = ["EUREX"]
     regular_market_times = {
-        "pre": ((None, time(1)),),
         "market_open": ((None, time(8)),),
         "market_close": ((None, time(22)),),
     }

--- a/pandas_market_calendars/calendars/eurex.py
+++ b/pandas_market_calendars/calendars/eurex.py
@@ -130,3 +130,30 @@ class EUREXExchangeCalendar(MarketCalendar):
                 ),
             )
         ]
+
+
+class EUREXPrePostExchangeCalendar(EUREXExchangeCalendar):
+    """
+    EUREX calendar variant with explicit pre and post sessions.
+
+    Issue #184 requested these session endpoints in UTC. This calendar keeps
+    those endpoints in UTC instead of interpreting them as Europe/Berlin wall
+    times, which would shift them across daylight-saving transitions.
+    """
+
+    aliases = ["EUREX_PrePost", "EUREX_Extended"]
+
+    regular_market_times = {
+        "pre": ((None, time(0, 15)),),
+        "market_open": ((None, time(8)),),
+        "market_close": ((None, time(16, 30)),),
+        "post": ((None, time(21)),),
+    }
+
+    @property
+    def name(self):
+        return "EUREX_PrePost"
+
+    @property
+    def tz(self):
+        return ZoneInfo("UTC")

--- a/pandas_market_calendars/calendars/eurex.py
+++ b/pandas_market_calendars/calendars/eurex.py
@@ -157,3 +157,32 @@ class EUREXPrePostExchangeCalendar(EUREXExchangeCalendar):
     @property
     def tz(self):
         return ZoneInfo("UTC")
+
+    @property
+    def _extended_early_close_rules(self):
+        return [
+            ChristmasEve,
+            EUREXNewYearsEve,
+        ]
+
+    @property
+    def special_closes(self):
+        return [
+            (
+                time(11, 30),
+                AbstractHolidayCalendar(
+                    rules=self._extended_early_close_rules
+                ),
+            )
+        ]
+
+    @property
+    def special_post(self):
+        return [
+            (
+                time(11, 30),
+                AbstractHolidayCalendar(
+                    rules=self._extended_early_close_rules
+                ),
+            )
+        ]

--- a/pandas_market_calendars/calendars/mirror.py
+++ b/pandas_market_calendars/calendars/mirror.py
@@ -8,7 +8,7 @@ import exchange_calendars
 import pandas as pd
 from pandas.tseries.offsets import CustomBusinessDay
 
-from pandas_market_calendars.market_calendar import MarketCalendar
+from pandas_market_calendars.market_calendar import HolidayCalendar, MarketCalendar
 
 
 DAYMASKS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -83,7 +83,10 @@ class TradingCalendar(MarketCalendar):
 
     @property
     def regular_holidays(self):
-        return self._ec.regular_holidays
+        regular_holidays = self._ec.regular_holidays
+        if regular_holidays is None or not hasattr(regular_holidays, "rules"):
+            return regular_holidays
+        return HolidayCalendar(rules=regular_holidays.rules, start_date="1885-01-01")
 
     @property
     def adhoc_holidays(self):

--- a/pandas_market_calendars/calendars/mirror.py
+++ b/pandas_market_calendars/calendars/mirror.py
@@ -12,6 +12,8 @@ from pandas_market_calendars.market_calendar import HolidayCalendar, MarketCalen
 
 
 DAYMASKS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+MIRROR_HOLIDAY_START_DATES = {"XNYS": "1885-01-01"}
+
 
 # XTAE (Tel Aviv Stock Exchange) changed from Sun-Thu to Mon-Fri on Jan 5, 2026
 XTAE_TRANSITION_DATE = pd.Timestamp("2026-01-05")
@@ -84,9 +86,10 @@ class TradingCalendar(MarketCalendar):
     @property
     def regular_holidays(self):
         regular_holidays = self._ec.regular_holidays
-        if regular_holidays is None or not hasattr(regular_holidays, "rules"):
+        start_date = MIRROR_HOLIDAY_START_DATES.get(self.name)
+        if start_date is None or regular_holidays is None or not hasattr(regular_holidays, "rules"):
             return regular_holidays
-        return HolidayCalendar(rules=regular_holidays.rules, start_date="1885-01-01")
+        return HolidayCalendar(rules=regular_holidays.rules, start_date=start_date)
 
     @property
     def adhoc_holidays(self):
@@ -131,6 +134,8 @@ time_props = {
 
 for exchange in calendars:
     cal = calendars[exchange]
+    if exchange in MarketCalendar._regmeta_class_registry:
+        continue
 
     # this loop will set up the newly required regular_market_times dictionary
     regular_market_times = {}

--- a/pandas_market_calendars/calendars/nyse.py
+++ b/pandas_market_calendars/calendars/nyse.py
@@ -303,15 +303,12 @@ from pandas_market_calendars.holidays.nyse import (
     # 1924
     WoodrowWilsonFuneral1230EarlyClose1924,
 )
-from pandas_market_calendars.market_calendar import MarketCalendar
+from pandas_market_calendars.market_calendar import HolidayCalendar, MarketCalendar
 
 
 # Useful resources for making changes to this file:
 # http://www.nyse.com/pdfs/closings.pdf
 # http://www.stevemorse.org/jcal/whendid.html
-
-# Overwrite the default holiday calendar start_date of 1/1/70
-AbstractHolidayCalendar.start_date = "1885-01-01"
 
 
 class NYSEExchangeCalendar(MarketCalendar):
@@ -863,7 +860,8 @@ class NYSEExchangeCalendar(MarketCalendar):
 
     @property
     def regular_holidays(self):
-        return AbstractHolidayCalendar(
+        return HolidayCalendar(
+            start_date="1885-01-01",
             rules=[
                 USNewYearsDayNYSEpost1952,
                 USNewYearsDayNYSEpre1952,
@@ -894,7 +892,7 @@ class NYSEExchangeCalendar(MarketCalendar):
                 Christmas54to98NYSE,
                 ChristmasBefore1954,
                 USJuneteenthAfter2022,
-            ]
+            ],
         )
 
     @property

--- a/pandas_market_calendars/calendars/nyse.py
+++ b/pandas_market_calendars/calendars/nyse.py
@@ -1115,6 +1115,23 @@ class NYSEExchangeCalendar(MarketCalendar):
         ]
 
     @property
+    def special_post(self):
+        return [
+            (
+                time(17, tzinfo=ZoneInfo("America/New_York")),
+                AbstractHolidayCalendar(
+                    rules=[
+                        FridayAfterIndependenceDayNYSEpre2013,
+                        MonTuesThursBeforeIndependenceDay,
+                        WednesdayBeforeIndependenceDayPost2013,
+                        DayAfterThanksgiving1pmEarlyCloseInOrAfter1993,
+                        ChristmasEvePost1999Early1pmClose,
+                    ]
+                ),
+            )
+        ]
+
+    @property
     def special_closes_adhoc(self):
         def _union_many(indexes):
             # Merges a list of pd.DatetimeIndex objects, returns merged DatetimeIndex
@@ -1155,6 +1172,15 @@ class NYSEExchangeCalendar(MarketCalendar):
                 time(15, 30, tzinfo=ZoneInfo("America/New_York")),
                 Backlog330pmEarlyCloses1987,  # index
             ),
+        ]
+
+    @property
+    def special_post_adhoc(self):
+        return [
+            (
+                time(17, tzinfo=ZoneInfo("America/New_York")),
+                ChristmasEve1pmEarlyCloseAdhoc + DayAfterChristmas1pmEarlyCloseAdhoc + BacklogRelief1pmEarlyClose1929,
+            )
         ]
 
     @property

--- a/pandas_market_calendars/calendars/nyse.py
+++ b/pandas_market_calendars/calendars/nyse.py
@@ -995,6 +995,20 @@ class NYSEExchangeCalendar(MarketCalendar):
         )
 
     @property
+    def _regular_1pm_post_close_rules(self):
+        return [
+            FridayAfterIndependenceDayNYSEpre2013,
+            MonTuesThursBeforeIndependenceDay,
+            WednesdayBeforeIndependenceDayPost2013,
+            DayAfterThanksgiving1pmEarlyCloseInOrAfter1993,
+            ChristmasEvePost1999Early1pmClose,
+        ]
+
+    @property
+    def _adhoc_1pm_post_close_dates(self):
+        return ChristmasEve1pmEarlyCloseAdhoc + DayAfterChristmas1pmEarlyCloseAdhoc + BacklogRelief1pmEarlyClose1929
+
+    @property
     def special_closes(self):
         return [
             (
@@ -1031,12 +1045,8 @@ class NYSEExchangeCalendar(MarketCalendar):
             (
                 time(13, tzinfo=ZoneInfo("America/New_York")),
                 AbstractHolidayCalendar(
-                    rules=[
-                        FridayAfterIndependenceDayNYSEpre2013,
-                        MonTuesThursBeforeIndependenceDay,
-                        WednesdayBeforeIndependenceDayPost2013,
-                        DayAfterThanksgiving1pmEarlyCloseInOrAfter1993,
-                        ChristmasEvePost1999Early1pmClose,
+                    rules=self._regular_1pm_post_close_rules
+                    + [
                         GroverClevelandFuneral1pmClose1908,
                     ]
                 ),
@@ -1120,13 +1130,7 @@ class NYSEExchangeCalendar(MarketCalendar):
             (
                 time(17, tzinfo=ZoneInfo("America/New_York")),
                 AbstractHolidayCalendar(
-                    rules=[
-                        FridayAfterIndependenceDayNYSEpre2013,
-                        MonTuesThursBeforeIndependenceDay,
-                        WednesdayBeforeIndependenceDayPost2013,
-                        DayAfterThanksgiving1pmEarlyCloseInOrAfter1993,
-                        ChristmasEvePost1999Early1pmClose,
-                    ]
+                    rules=self._regular_1pm_post_close_rules
                 ),
             )
         ]
@@ -1143,8 +1147,7 @@ class NYSEExchangeCalendar(MarketCalendar):
         return [
             (
                 time(13, tzinfo=ZoneInfo("America/New_York")),
-                # DaysBeforeIndependenceDay1pmEarlyCloseAdhoc # list
-                ChristmasEve1pmEarlyCloseAdhoc + DayAfterChristmas1pmEarlyCloseAdhoc + BacklogRelief1pmEarlyClose1929,
+                self._adhoc_1pm_post_close_dates,
             ),
             (
                 time(14, tzinfo=ZoneInfo("America/New_York")),
@@ -1179,7 +1182,7 @@ class NYSEExchangeCalendar(MarketCalendar):
         return [
             (
                 time(17, tzinfo=ZoneInfo("America/New_York")),
-                ChristmasEve1pmEarlyCloseAdhoc + DayAfterChristmas1pmEarlyCloseAdhoc + BacklogRelief1pmEarlyClose1929,
+                self._adhoc_1pm_post_close_dates,
             )
         ]
 

--- a/pandas_market_calendars/holidays/cme_globex.py
+++ b/pandas_market_calendars/holidays/cme_globex.py
@@ -1,6 +1,6 @@
 from dateutil.relativedelta import MO, TH
 from pandas import DateOffset, Timestamp
-from pandas.tseries.holiday import Easter, Holiday, nearest_workday
+from pandas.tseries.holiday import Easter, Holiday, nearest_workday, sunday_to_monday
 from pandas.tseries.offsets import Day
 
 from pandas_market_calendars.market_calendar import (
@@ -20,7 +20,7 @@ USNewYearsDay = Holiday(
     month=1,
     day=1,
     start_date=Timestamp("1952-09-29"),
-    # observance=sunday_to_monday,
+    observance=sunday_to_monday,
     days_of_week=(
         MONDAY,
         TUESDAY,

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -828,6 +828,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         _adj_others = force_special_times is True
         _adj_col = force_special_times is not None
         _open_adj = _close_adj = []
+        _special_dates_by_time = {}
 
         schedule = pd.DataFrame()
         for market_time in market_times:
@@ -840,6 +841,8 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
                     special.index.isin(temp.index)
                 ]  # some sources of special times don't exclude holidays
                 temp.loc[specialix] = special
+                if len(specialix) > 0:
+                    _special_dates_by_time[market_time] = specialix
 
                 if _adj_others:
                     if market_time == "market_open":
@@ -864,11 +867,16 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         if _adj_others and len(_close_adj) > 0:
             mkt_close_ind = cols.get_loc("market_close")
 
-            def adjust_closes(x):
-                x[x >= x[mkt_close_ind]] = x[mkt_close_ind]
-                return x
+            def adjust_closes(row):
+                adjusted = row.copy()
+                mask = adjusted >= adjusted.iloc[mkt_close_ind]
+                for market_time, special_dates in _special_dates_by_time.items():
+                    if market_time != "market_close" and row.name in special_dates and market_time in mask.index:
+                        mask.loc[market_time] = False
+                adjusted.loc[mask] = adjusted.iloc[mkt_close_ind]
+                return adjusted
 
-            adjusted = schedule.loc[_close_adj].apply(adjust_closes, axis=1, raw=True)
+            adjusted = schedule.loc[_close_adj].apply(adjust_closes, axis=1)
             schedule.loc[_close_adj] = adjusted
 
         if interruptions:

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -606,12 +606,6 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         """
         return pd.date_range(start_date, end_date, freq=self.holidays(), normalize=True, tz=tz)
 
-    def _valid_days_for_schedule(self, start_date, end_date, tz="UTC") -> pd.DatetimeIndex:
-        return self.valid_days(start_date, end_date, tz=tz)
-
-    def _valid_days_for_special_times(self, start_date, end_date, tz="UTC") -> pd.DatetimeIndex:
-        return self.valid_days(start_date, end_date, tz=tz)
-
     def _get_market_times(self, start, end):
         mts = self._market_times
         return mts[mts.index(start) : mts.index(end) + 1]
@@ -719,7 +713,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         special = self._special_dates(calendars, ad_hoc, start_date, end_date)
 
         if filter_holidays:
-            valid = self._valid_days_for_special_times(start_date, end_date, tz=None)
+            valid = self.valid_days(start_date, end_date, tz=None)
             special = special[special.index.isin(valid)]  # some sources of special times don't exclude holidays
 
         self._special_dates_cache[cache_key] = special
@@ -767,7 +761,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         if not (start_date <= end_date):
             raise ValueError("start_date must be before or equal to end_date.")
 
-        _all_days = self._valid_days_for_schedule(start_date, end_date)
+        _all_days = self.valid_days(start_date, end_date)
 
         # Setup all valid trading days and the requested market_times
         if market_times is None:
@@ -809,7 +803,8 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         :param end: the last market_time to include as a column, default: "market_close"
         :param force_special_times: how to handle special times.
             True: overwrite regular times of the column itself, conform other columns to special times of
-                market_open/market_close if those are requested.
+                market_open/market_close if those are requested, and preserve any explicitly requested special time
+                for its own column.
             False: only overwrite regular times of the column itself, leave others alone
             None: completely ignore special times
         :param market_times: alternative to start/end, list of market_times that are in self.regular_market_times
@@ -881,6 +876,9 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             adjusted = schedule.loc[_close_adj].apply(adjust_closes, axis=1, raw=True)
             schedule.loc[_close_adj] = adjusted
 
+        # A market_time's own special value is authoritative. Apply non-open/close
+        # specials after open/close conformance so explicit values, such as NYSE
+        # early-close post sessions, are not silently clamped away.
         for market_time, special in _special_dates.items():
             if market_time not in ("market_open", "market_close"):
                 schedule.loc[special.index, market_time] = special

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -368,10 +368,8 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             # The time is already in UTC, convert to local timezone
             return special.loc[date].tz_convert(self.tz).time().replace(tzinfo=self.tz)
 
-        # Otherwise, return the regular time
-        for d, t in times[::-1]:
-            if d is None or pd.Timestamp(d) < date:
-                return t.replace(tzinfo=self.tz)
+        regular_time = self.days_at_time(pd.DatetimeIndex([date]), market_time).iloc[0]
+        return regular_time.tz_convert(self.tz).time().replace(tzinfo=self.tz)
 
     def open_time_on(self, date):
         return self.get_time_on("market_open", date)
@@ -828,7 +826,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         _adj_others = force_special_times is True
         _adj_col = force_special_times is not None
         _open_adj = _close_adj = []
-        _special_dates_by_time = {}
+        _special_dates = {}
 
         schedule = pd.DataFrame()
         for market_time in market_times:
@@ -836,21 +834,24 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
             if _adj_col:
                 # create an array of special times
                 special = self.special_dates(market_time, days[0], days[-1], filter_holidays=False)
-                # overwrite standard times
-                specialix = special.index[
-                    special.index.isin(temp.index)
-                ]  # some sources of special times don't exclude holidays
-                temp.loc[specialix] = special
+                # some sources of special times don't exclude holidays
+                specialix = special.index[special.index.isin(temp.index)]
                 if len(specialix) > 0:
-                    _special_dates_by_time[market_time] = specialix
+                    special = special.loc[specialix]
+                    _special_dates[market_time] = special
 
-                if _adj_others:
-                    if market_time == "market_open":
-                        _open_adj = specialix
-                    elif market_time == "market_close":
-                        _close_adj = specialix
+                    if _adj_others:
+                        if market_time == "market_open":
+                            _open_adj = specialix
+                        elif market_time == "market_close":
+                            _close_adj = specialix
 
             schedule[market_time] = temp
+
+        for market_time in ("market_open", "market_close"):
+            special = _special_dates.get(market_time)
+            if special is not None:
+                schedule.loc[special.index, market_time] = special
 
         cols = schedule.columns
         if _adj_others and len(_open_adj) > 0:
@@ -867,17 +868,16 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         if _adj_others and len(_close_adj) > 0:
             mkt_close_ind = cols.get_loc("market_close")
 
-            def adjust_closes(row):
-                adjusted = row.copy()
-                mask = adjusted >= adjusted.iloc[mkt_close_ind]
-                for market_time, special_dates in _special_dates_by_time.items():
-                    if market_time != "market_close" and row.name in special_dates and market_time in mask.index:
-                        mask.loc[market_time] = False
-                adjusted.loc[mask] = adjusted.iloc[mkt_close_ind]
-                return adjusted
+            def adjust_closes(x):
+                x[x >= x[mkt_close_ind]] = x[mkt_close_ind]
+                return x
 
-            adjusted = schedule.loc[_close_adj].apply(adjust_closes, axis=1)
+            adjusted = schedule.loc[_close_adj].apply(adjust_closes, axis=1, raw=True)
             schedule.loc[_close_adj] = adjusted
+
+        for market_time, special in _special_dates.items():
+            if market_time not in ("market_open", "market_close"):
+                schedule.loc[special.index, market_time] = special
 
         if interruptions:
             interrs = self.interruptions_df

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -606,6 +606,12 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         """
         return pd.date_range(start_date, end_date, freq=self.holidays(), normalize=True, tz=tz)
 
+    def _valid_days_for_schedule(self, start_date, end_date, tz="UTC") -> pd.DatetimeIndex:
+        return self.valid_days(start_date, end_date, tz=tz)
+
+    def _valid_days_for_special_times(self, start_date, end_date, tz="UTC") -> pd.DatetimeIndex:
+        return self.valid_days(start_date, end_date, tz=tz)
+
     def _get_market_times(self, start, end):
         mts = self._market_times
         return mts[mts.index(start) : mts.index(end) + 1]
@@ -713,7 +719,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         special = self._special_dates(calendars, ad_hoc, start_date, end_date)
 
         if filter_holidays:
-            valid = self.valid_days(start_date, end_date, tz=None)
+            valid = self._valid_days_for_special_times(start_date, end_date, tz=None)
             special = special[special.index.isin(valid)]  # some sources of special times don't exclude holidays
 
         self._special_dates_cache[cache_key] = special
@@ -761,7 +767,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         if not (start_date <= end_date):
             raise ValueError("start_date must be before or equal to end_date.")
 
-        _all_days = self.valid_days(start_date, end_date)
+        _all_days = self._valid_days_for_schedule(start_date, end_date)
 
         # Setup all valid trading days and the requested market_times
         if market_times is None:

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -20,6 +20,7 @@ from datetime import time
 from typing import List, Literal, Union
 
 import pandas as pd
+from pandas.tseries.holiday import AbstractHolidayCalendar
 from pandas.tseries.offsets import CustomBusinessDay
 
 from . import calendar_utils as u
@@ -38,6 +39,28 @@ WEEKMASK_ABBR = {
     SATURDAY: "Sat",
     SUNDAY: "Sun",
 }
+
+
+class HolidayCalendar(AbstractHolidayCalendar):
+    """
+    Holiday calendar with instance-local default bounds.
+
+    pandas' ``AbstractHolidayCalendar.holidays()`` reads the pandas base class
+    defaults when callers omit start/end. This class lets market calendars
+    choose wider or narrower defaults without mutating pandas global state.
+    """
+
+    def __init__(self, *args, start_date=None, end_date=None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.start_date = pd.Timestamp(start_date) if start_date is not None else AbstractHolidayCalendar.start_date
+        self.end_date = pd.Timestamp(end_date) if end_date is not None else AbstractHolidayCalendar.end_date
+
+    def holidays(self, start=None, end=None, return_name: bool = False) -> pd.DatetimeIndex | pd.Series:
+        if start is None:
+            start = self.start_date
+        if end is None:
+            end = self.end_date
+        return super().holidays(start=start, end=end, return_name=return_name)
 
 
 class DEFAULT:

--- a/pandas_market_calendars/market_calendar.py
+++ b/pandas_market_calendars/market_calendar.py
@@ -355,17 +355,10 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
         if times is None:
             return None
 
-        # Normalize date to midnight to properly match against special dates index
-        date = pd.Timestamp(date).normalize()
+        date, _ = self.clean_dates(date, date)
 
-        # Check for special times on this specific date
-        # Use the date itself for both start and end to check just this one day
-        special = self.special_dates(market_time, date, date, filter_holidays=False)
-
-        # If there's a special time for this date, return it
-        if len(special) > 0 and date in special.index:
-            # special is a Series with dates as index and times as values
-            # The time is already in UTC, convert to local timezone
+        special = self.special_dates(market_time, date, date, filter_holidays=True)
+        if date in special.index:
             return special.loc[date].tz_convert(self.tz).time().replace(tzinfo=self.tz)
 
         regular_time = self.days_at_time(pd.DatetimeIndex([date]), market_time).iloc[0]
@@ -774,6 +767,55 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
         return self.schedule_from_days(_all_days, tz, start, end, force_special_times, market_times, interruptions)
 
+    def _apply_special_times(self, schedule, special_dates, open_adj, close_adj, force_special_times):
+        """
+        Apply special times to a schedule.
+
+        A market time's own special value is authoritative.  Open/close
+        specials can still conform other requested columns, but explicit
+        non-open/close specials are restored afterwards so values such as
+        NYSE early-close post sessions are not silently clamped away.
+
+        :param schedule: schedule DataFrame
+        :param special_dates: mapping of market time names to special timestamps
+        :param open_adj: dates with a special market open
+        :param close_adj: dates with a special market close
+        :param force_special_times: schedule force_special_times argument
+        :return: schedule DataFrame with special times applied
+        """
+        for market_time in ("market_open", "market_close"):
+            special = special_dates.get(market_time)
+            if special is not None:
+                schedule.loc[special.index, market_time] = special
+
+        cols = schedule.columns
+        if force_special_times is True and len(open_adj) > 0:
+            mkt_open_ind = cols.get_loc("market_open")
+
+            # Can't use Lambdas here since numpy array assignment doesn't return the array.
+            def adjust_opens(x):  # x is an np.Array.
+                x[x <= x[mkt_open_ind]] = x[mkt_open_ind]
+                return x
+
+            adjusted = schedule.loc[open_adj].apply(adjust_opens, axis=1, raw=True)
+            schedule.loc[open_adj] = adjusted
+
+        if force_special_times is True and len(close_adj) > 0:
+            mkt_close_ind = cols.get_loc("market_close")
+
+            def adjust_closes(x):
+                x[x >= x[mkt_close_ind]] = x[mkt_close_ind]
+                return x
+
+            adjusted = schedule.loc[close_adj].apply(adjust_closes, axis=1, raw=True)
+            schedule.loc[close_adj] = adjusted
+
+        for market_time, special in special_dates.items():
+            if market_time not in ("market_open", "market_close"):
+                schedule.loc[special.index, market_time] = special
+
+        return schedule
+
     def schedule_from_days(
         self,
         days: pd.DatetimeIndex,
@@ -849,39 +891,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
             schedule[market_time] = temp
 
-        for market_time in ("market_open", "market_close"):
-            special = _special_dates.get(market_time)
-            if special is not None:
-                schedule.loc[special.index, market_time] = special
-
-        cols = schedule.columns
-        if _adj_others and len(_open_adj) > 0:
-            mkt_open_ind = cols.get_loc("market_open")
-
-            # Can't use Lambdas here since numpy array assignment doesn't return the array.
-            def adjust_opens(x):  # x is an np.Array.
-                x[x <= x[mkt_open_ind]] = x[mkt_open_ind]
-                return x
-
-            adjusted = schedule.loc[_open_adj].apply(adjust_opens, axis=1, raw=True)
-            schedule.loc[_open_adj] = adjusted
-
-        if _adj_others and len(_close_adj) > 0:
-            mkt_close_ind = cols.get_loc("market_close")
-
-            def adjust_closes(x):
-                x[x >= x[mkt_close_ind]] = x[mkt_close_ind]
-                return x
-
-            adjusted = schedule.loc[_close_adj].apply(adjust_closes, axis=1, raw=True)
-            schedule.loc[_close_adj] = adjusted
-
-        # A market_time's own special value is authoritative. Apply non-open/close
-        # specials after open/close conformance so explicit values, such as NYSE
-        # early-close post sessions, are not silently clamped away.
-        for market_time, special in _special_dates.items():
-            if market_time not in ("market_open", "market_close"):
-                schedule.loc[special.index, market_time] = special
+        schedule = self._apply_special_times(schedule, _special_dates, _open_adj, _close_adj, force_special_times)
 
         if interruptions:
             interrs = self.interruptions_df
@@ -1006,7 +1016,7 @@ class MarketCalendar(metaclass=MarketCalendarMeta):
 
         # When post follows market_close, market_close should not be considered a close
         day.loc[day.eq("market_close") & day.shift(-1).eq("post")] = "market_open"
-        day = day.map(lambda x: (self.open_close_map.get(x) if x in self.open_close_map else x))
+        day = day.map(lambda x: self.open_close_map.get(x) if x in self.open_close_map else x)
 
         below = day.index <= timestamp
         last_below = day[below]

--- a/pandas_market_calendars/sources.py
+++ b/pandas_market_calendars/sources.py
@@ -85,7 +85,7 @@ CALENDAR_SOURCES: dict[str, tuple[Source, ...]] = {
             url="https://www.nseindia.com/resources/exchange-communication-holidays",
             last_verified="2025-01-24",
             covers="holidays",
-            notes="BSE and NSE India share the same holiday schedule",
+            notes="BSE and NSE holidays are modeled as separate calendars because exchange holidays can diverge",
         ),
     ),
     "NSE": (

--- a/tests/test_bse_calendar.py
+++ b/tests/test_bse_calendar.py
@@ -4,20 +4,39 @@ import pandas as pd
 import pytest
 from zoneinfo import ZoneInfo
 
-from pandas_market_calendars.calendars.bse import BSEClosedDay, BSEExchangeCalendar
+from pandas_market_calendars import get_calendar
+from pandas_market_calendars.calendars.bse import BSEClosedDay, BSEExchangeCalendar, NSEClosedDay, NSEExchangeCalendar
 
 
 def test_time_zone():
     assert BSEExchangeCalendar().tz == ZoneInfo("Asia/Calcutta")
     assert BSEExchangeCalendar().name == "BSE"
+    assert NSEExchangeCalendar().tz == ZoneInfo("Asia/Calcutta")
+    assert NSEExchangeCalendar().name == "NSE"
 
 
 def test_holidays():
     bse_calendar = BSEExchangeCalendar()
 
-    trading_days = bse_calendar.valid_days(pd.Timestamp("2004-01-01"), pd.Timestamp("2018-12-31"))
+    trading_days = bse_calendar.valid_days(pd.Timestamp("1997-01-01"), pd.Timestamp("2026-12-31"))
     for session_label in BSEClosedDay:
         assert session_label not in trading_days
+
+    nse_calendar = NSEExchangeCalendar()
+    nse_trading_days = nse_calendar.valid_days(pd.Timestamp("2004-01-01"), pd.Timestamp("2026-12-31"))
+    for session_label in NSEClosedDay:
+        assert session_label not in nse_trading_days
+
+    assert pd.Timestamp("2024-05-20", tz="UTC") not in bse_calendar.valid_days("2024-05-17", "2024-05-21")
+    assert pd.Timestamp("2024-05-20", tz="UTC") not in nse_calendar.valid_days("2024-05-17", "2024-05-21")
+
+
+def test_bse_and_nse_aliases_are_separate_calendars():
+    assert get_calendar("BSE").name == "BSE"
+    assert get_calendar("NSE").name == "NSE"
+    assert get_calendar("XNSE").name == "NSE"
+    assert get_calendar("XNSE").name != get_calendar("BSE").name
+    assert pd.Timestamp("2024-05-20", tz="UTC") not in get_calendar("XBOM").valid_days("2024-05-17", "2024-05-21")
 
 
 def test_open_close_time():

--- a/tests/test_bse_calendar.py
+++ b/tests/test_bse_calendar.py
@@ -33,10 +33,13 @@ def test_holidays():
 
 def test_bse_and_nse_aliases_are_separate_calendars():
     assert get_calendar("BSE").name == "BSE"
+    assert get_calendar("XBOM").name == "XBOM"
     assert get_calendar("NSE").name == "NSE"
     assert get_calendar("XNSE").name == "NSE"
     assert get_calendar("XNSE").name != get_calendar("BSE").name
+
     assert pd.Timestamp("2024-05-20", tz="UTC") not in get_calendar("XBOM").valid_days("2024-05-17", "2024-05-21")
+    assert pd.Timestamp("2024-05-20", tz="UTC") not in get_calendar("XNSE").valid_days("2024-05-17", "2024-05-21")
 
 
 def test_open_close_time():

--- a/tests/test_bse_calendar.py
+++ b/tests/test_bse_calendar.py
@@ -23,7 +23,7 @@ def test_holidays():
         assert session_label not in trading_days
 
     nse_calendar = NSEExchangeCalendar()
-    nse_trading_days = nse_calendar.valid_days(pd.Timestamp("2004-01-01"), pd.Timestamp("2026-12-31"))
+    nse_trading_days = nse_calendar.valid_days(pd.Timestamp("1997-01-01"), pd.Timestamp("2026-12-31"))
     for session_label in NSEClosedDay:
         assert session_label not in nse_trading_days
 
@@ -33,7 +33,7 @@ def test_holidays():
 
 def test_bse_and_nse_aliases_are_separate_calendars():
     assert get_calendar("BSE").name == "BSE"
-    assert get_calendar("XBOM").name == "XBOM"
+    assert get_calendar("XBOM").name == "BSE"
     assert get_calendar("NSE").name == "NSE"
     assert get_calendar("XNSE").name == "NSE"
     assert get_calendar("XNSE").name != get_calendar("BSE").name

--- a/tests/test_cme_agriculture_calendar.py
+++ b/tests/test_cme_agriculture_calendar.py
@@ -2,11 +2,26 @@ import pandas as pd
 from zoneinfo import ZoneInfo
 
 from pandas_market_calendars.calendars.cme import CMEAgricultureExchangeCalendar
+from pandas_market_calendars.calendars.cme_globex_agriculture import CMEGlobexGrainsAndOilseedsExchangeCalendar
 
 
 def test_time_zone():
     assert CMEAgricultureExchangeCalendar().tz == ZoneInfo("America/Chicago")
     assert CMEAgricultureExchangeCalendar().name == "CME_Agriculture"
+
+
+def test_regular_market_times_match_grains_union():
+    cme = CMEAgricultureExchangeCalendar()
+    grains = CMEGlobexGrainsAndOilseedsExchangeCalendar()
+
+    assert cme.regular_market_times == grains.regular_market_times
+
+    schedule = cme.schedule("2024-11-25", "2024-11-25", tz="America/Chicago")
+    session = schedule.loc["2024-11-25"]
+    assert session.market_open == pd.Timestamp("2024-11-24 19:00:00", tz=cme.tz)
+    assert session.break_start == pd.Timestamp("2024-11-25 07:45:00", tz=cme.tz)
+    assert session.break_end == pd.Timestamp("2024-11-25 08:30:00", tz=cme.tz)
+    assert session.market_close == pd.Timestamp("2024-11-25 13:20:00", tz=cme.tz)
 
 
 def test_2020_holidays():
@@ -44,5 +59,5 @@ def test_dec_jan():
     cme = CMEAgricultureExchangeCalendar()
     schedule = cme.schedule("2020-12-30", "2021-01-10")
 
-    assert schedule["market_open"].iloc[0] == pd.Timestamp("2020-12-29 23:01:00", tz="UTC")
-    assert schedule["market_close"].iloc[6] == pd.Timestamp("2021-01-08 23:00:00", tz="UTC")
+    assert schedule["market_open"].iloc[0] == pd.Timestamp("2020-12-30 01:00:00", tz="UTC")
+    assert schedule["market_close"].iloc[6] == pd.Timestamp("2021-01-08 19:20:00", tz="UTC")

--- a/tests/test_cme_agriculture_calendar.py
+++ b/tests/test_cme_agriculture_calendar.py
@@ -2,7 +2,6 @@ import pandas as pd
 from zoneinfo import ZoneInfo
 
 from pandas_market_calendars.calendars.cme import CMEAgricultureExchangeCalendar
-from pandas_market_calendars.calendars.cme_globex_agriculture import CMEGlobexGrainsAndOilseedsExchangeCalendar
 
 
 def test_time_zone():
@@ -10,12 +9,8 @@ def test_time_zone():
     assert CMEAgricultureExchangeCalendar().name == "CME_Agriculture"
 
 
-def test_regular_market_times_match_grains_union():
+def test_regular_market_times_match_grains_public_hours():
     cme = CMEAgricultureExchangeCalendar()
-    grains = CMEGlobexGrainsAndOilseedsExchangeCalendar()
-
-    assert cme.regular_market_times == grains.regular_market_times
-
     schedule = cme.schedule("2024-11-25", "2024-11-25", tz="America/Chicago")
     session = schedule.loc["2024-11-25"]
     assert session.market_open == pd.Timestamp("2024-11-24 19:00:00", tz=cme.tz)

--- a/tests/test_cme_equity_calendar.py
+++ b/tests/test_cme_equity_calendar.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from zoneinfo import ZoneInfo
 
-from pandas_market_calendars.calendars.cme import CMEEquityExchangeCalendar
+from pandas_market_calendars.calendars.cme import CMEEquityExchangeCalendar, CMETradeDateCalendar
 
 
 def test_time_zone():
@@ -58,6 +58,39 @@ def test_dec_jan():
 
     assert schedule["market_open"].iloc[0] == pd.Timestamp("2016-12-29 23:00:00", tz="UTC")
     assert schedule["market_close"].iloc[6] == pd.Timestamp("2017-01-10 22:00:00", tz="UTC")
+
+
+def test_historical_trade_date_open_before_2012_hours_change():
+    cme = CMEEquityExchangeCalendar()
+    schedule = cme.schedule("2005-09-12", "2012-11-19", tz="America/Chicago")
+
+    assert schedule.loc["2005-09-12"].market_open == pd.Timestamp("2005-09-11 15:30:00", tz=cme.tz)
+    assert schedule.loc["2012-11-16"].market_open == pd.Timestamp("2012-11-15 15:30:00", tz=cme.tz)
+    assert schedule.loc["2012-11-19"].market_open == pd.Timestamp("2012-11-18 17:00:00", tz=cme.tz)
+
+    assert schedule.loc["2012-11-16"].market_close == pd.Timestamp("2012-11-16 15:15:00", tz=cme.tz)
+    assert schedule.loc["2012-11-16"].break_start == schedule.loc["2012-11-16"].break_end
+    assert cme.open_at_time(schedule, "2012-11-16 15:14:59-06:00") is True
+    assert cme.open_at_time(schedule, "2012-11-16 15:15:00-06:00") is False
+    assert cme.open_at_time(schedule, "2012-11-16 15:20:00-06:00") is False
+    assert cme.open_at_time(schedule, "2012-11-19 15:31:00-06:00") is True
+
+
+def test_2023_good_friday_has_early_close_session():
+    cme = CMEEquityExchangeCalendar()
+    schedule = cme.schedule("2023-04-06", "2023-04-10", tz="America/New_York")
+
+    session = schedule.loc["2023-04-07"]
+    assert session.market_open == pd.Timestamp("2023-04-06 18:00:00", tz="America/New_York")
+    assert session.market_close == pd.Timestamp("2023-04-07 09:15:00", tz="America/New_York")
+
+
+def test_trade_date_calendar_excludes_equity_early_close_holidays():
+    trade_dates = CMETradeDateCalendar().valid_days("2024-05-24", "2024-05-29")
+    equity_schedule = CMEEquityExchangeCalendar().schedule("2024-05-24", "2024-05-29", tz="America/Chicago")
+
+    assert pd.Timestamp("2024-05-27", tz="UTC") not in trade_dates
+    assert equity_schedule.loc["2024-05-27"].market_close == pd.Timestamp("2024-05-27 12:00:00", tz="America/Chicago")
 
 
 def test_good_friday_2026_has_early_close_session():

--- a/tests/test_cme_equity_calendar.py
+++ b/tests/test_cme_equity_calendar.py
@@ -102,17 +102,14 @@ def test_2023_good_friday_has_early_close_session():
 
 
 def test_trade_date_calendar_excludes_equity_early_close_holidays():
-    cme = CMEEquityExchangeCalendar()
     trade_dates = CMETradeDateCalendar().valid_days("2024-05-24", "2024-05-29")
-    equity_trade_dates = cme.valid_days("2024-05-24", "2024-05-29")
-    equity_schedule = cme.schedule("2024-05-24", "2024-05-29", tz="America/Chicago")
+    equity_schedule = CMEEquityExchangeCalendar().schedule("2024-05-24", "2024-05-29", tz="America/Chicago")
 
-    assert list(equity_trade_dates) == list(trade_dates)
-    assert pd.Timestamp("2024-05-27", tz="UTC") not in equity_trade_dates
+    assert pd.Timestamp("2024-05-27", tz="UTC") not in trade_dates
     assert equity_schedule.loc["2024-05-27"].market_close == pd.Timestamp("2024-05-27 12:00:00", tz="America/Chicago")
 
 
-def test_equity_valid_days_are_trade_dates_but_schedule_keeps_early_close_sessions():
+def test_trade_date_calendar_excludes_settlement_holidays_without_dropping_equity_sessions():
     cme = CMEEquityExchangeCalendar()
     issue_dates = [
         "2022-01-17",
@@ -133,16 +130,13 @@ def test_equity_valid_days_are_trade_dates_but_schedule_keeps_early_close_sessio
         "2024-02-19",
     ]
 
-    valid_days = cme.valid_days("2022-01-01", "2024-02-29")
+    trade_dates = CMETradeDateCalendar().valid_days("2022-01-01", "2024-02-29")
     schedule = cme.schedule("2022-01-01", "2024-02-29")
 
     for date in issue_dates:
         timestamp = pd.Timestamp(date, tz="UTC")
-        assert timestamp not in valid_days
+        assert timestamp not in trade_dates
         assert pd.Timestamp(date) in schedule.index
-
-    special_closes = cme.special_dates("market_close", "2024-05-24", "2024-05-29")
-    assert pd.Timestamp("2024-05-27") in special_closes.index
 
 
 def test_good_friday_2026_has_early_close_session():

--- a/tests/test_cme_equity_calendar.py
+++ b/tests/test_cme_equity_calendar.py
@@ -76,6 +76,22 @@ def test_historical_trade_date_open_before_2012_hours_change():
     assert cme.open_at_time(schedule, "2012-11-19 15:31:00-06:00") is True
 
 
+def test_historical_trade_date_time_helpers_match_schedule_cutovers():
+    cme = CMEEquityExchangeCalendar()
+
+    assert cme.open_time_on("2005-09-12").hour == 15
+    assert cme.open_time_on("2005-09-12").minute == 30
+    assert cme.close_time_on("2005-09-12").hour == 15
+    assert cme.close_time_on("2005-09-12").minute == 15
+    assert cme.break_end_on("2005-09-12").hour == 15
+    assert cme.break_end_on("2005-09-12").minute == 15
+
+    assert cme.open_time_on("2012-11-19").hour == 17
+    assert cme.close_time_on("2012-11-19").hour == 16
+    assert cme.break_end_on("2012-11-19").hour == 15
+    assert cme.break_end_on("2012-11-19").minute == 30
+
+
 def test_2023_good_friday_has_early_close_session():
     cme = CMEEquityExchangeCalendar()
     schedule = cme.schedule("2023-04-06", "2023-04-10", tz="America/New_York")

--- a/tests/test_cme_equity_calendar.py
+++ b/tests/test_cme_equity_calendar.py
@@ -111,7 +111,7 @@ def test_trade_date_calendar_excludes_equity_early_close_holidays():
 
 def test_trade_date_calendar_excludes_settlement_holidays_without_dropping_equity_sessions():
     cme = CMEEquityExchangeCalendar()
-    issue_dates = [
+    early_close_dates = [
         "2022-01-17",
         "2022-02-21",
         "2022-05-30",
@@ -131,12 +131,13 @@ def test_trade_date_calendar_excludes_settlement_holidays_without_dropping_equit
     ]
 
     trade_dates = CMETradeDateCalendar().valid_days("2022-01-01", "2024-02-29")
-    schedule = cme.schedule("2022-01-01", "2024-02-29")
+    schedule = cme.schedule("2022-01-01", "2024-02-29", tz=cme.tz)
 
-    for date in issue_dates:
+    for date in early_close_dates:
         timestamp = pd.Timestamp(date, tz="UTC")
+        expected_close = pd.Timestamp(f"{date} 12:00:00", tz=cme.tz)
         assert timestamp not in trade_dates
-        assert pd.Timestamp(date) in schedule.index
+        assert schedule.loc[date].market_close == expected_close
 
 
 def test_good_friday_2026_has_early_close_session():

--- a/tests/test_cme_equity_calendar.py
+++ b/tests/test_cme_equity_calendar.py
@@ -102,11 +102,47 @@ def test_2023_good_friday_has_early_close_session():
 
 
 def test_trade_date_calendar_excludes_equity_early_close_holidays():
+    cme = CMEEquityExchangeCalendar()
     trade_dates = CMETradeDateCalendar().valid_days("2024-05-24", "2024-05-29")
-    equity_schedule = CMEEquityExchangeCalendar().schedule("2024-05-24", "2024-05-29", tz="America/Chicago")
+    equity_trade_dates = cme.valid_days("2024-05-24", "2024-05-29")
+    equity_schedule = cme.schedule("2024-05-24", "2024-05-29", tz="America/Chicago")
 
-    assert pd.Timestamp("2024-05-27", tz="UTC") not in trade_dates
+    assert list(equity_trade_dates) == list(trade_dates)
+    assert pd.Timestamp("2024-05-27", tz="UTC") not in equity_trade_dates
     assert equity_schedule.loc["2024-05-27"].market_close == pd.Timestamp("2024-05-27 12:00:00", tz="America/Chicago")
+
+
+def test_equity_valid_days_are_trade_dates_but_schedule_keeps_early_close_sessions():
+    cme = CMEEquityExchangeCalendar()
+    issue_dates = [
+        "2022-01-17",
+        "2022-02-21",
+        "2022-05-30",
+        "2022-06-20",
+        "2022-07-04",
+        "2022-09-05",
+        "2022-11-24",
+        "2023-01-16",
+        "2023-02-20",
+        "2023-05-29",
+        "2023-06-19",
+        "2023-07-04",
+        "2023-09-04",
+        "2023-11-23",
+        "2024-01-15",
+        "2024-02-19",
+    ]
+
+    valid_days = cme.valid_days("2022-01-01", "2024-02-29")
+    schedule = cme.schedule("2022-01-01", "2024-02-29")
+
+    for date in issue_dates:
+        timestamp = pd.Timestamp(date, tz="UTC")
+        assert timestamp not in valid_days
+        assert pd.Timestamp(date) in schedule.index
+
+    special_closes = cme.special_dates("market_close", "2024-05-24", "2024-05-29")
+    assert pd.Timestamp("2024-05-27") in special_closes.index
 
 
 def test_good_friday_2026_has_early_close_session():

--- a/tests/test_eurex_calendar.py
+++ b/tests/test_eurex_calendar.py
@@ -12,18 +12,16 @@ def test_time_zone():
 def test_regular_market_times():
     eurex = EUREXExchangeCalendar()
 
-    assert eurex.regular_market_times["pre"] == ((None, pd.Timestamp("01:00").time()),)
+    assert "pre" not in eurex.regular_market_times
     assert eurex.regular_market_times["market_open"] == ((None, pd.Timestamp("08:00").time()),)
     assert eurex.regular_market_times["market_close"] == ((None, pd.Timestamp("22:00").time()),)
 
     schedule = eurex.schedule(
         "2025-03-07",
         "2025-03-07",
-        market_times=["pre", "market_open", "market_close"],
         tz="Europe/Berlin",
     )
     session = schedule.loc["2025-03-07"]
-    assert session.pre == pd.Timestamp("2025-03-07 01:00", tz=eurex.tz)
     assert session.market_open == pd.Timestamp("2025-03-07 08:00", tz=eurex.tz)
     assert session.market_close == pd.Timestamp("2025-03-07 22:00", tz=eurex.tz)
 

--- a/tests/test_eurex_calendar.py
+++ b/tests/test_eurex_calendar.py
@@ -9,6 +9,25 @@ def test_time_zone():
     assert EUREXExchangeCalendar().name == "EUREX"
 
 
+def test_regular_market_times():
+    eurex = EUREXExchangeCalendar()
+
+    assert eurex.regular_market_times["pre"] == ((None, pd.Timestamp("01:00").time()),)
+    assert eurex.regular_market_times["market_open"] == ((None, pd.Timestamp("08:00").time()),)
+    assert eurex.regular_market_times["market_close"] == ((None, pd.Timestamp("22:00").time()),)
+
+    schedule = eurex.schedule(
+        "2025-03-07",
+        "2025-03-07",
+        market_times=["pre", "market_open", "market_close"],
+        tz="Europe/Berlin",
+    )
+    session = schedule.loc["2025-03-07"]
+    assert session.pre == pd.Timestamp("2025-03-07 01:00", tz=eurex.tz)
+    assert session.market_open == pd.Timestamp("2025-03-07 08:00", tz=eurex.tz)
+    assert session.market_close == pd.Timestamp("2025-03-07 22:00", tz=eurex.tz)
+
+
 def test_2016_holidays():
     # good friday: 2016-03-25
     # May 1st: on a weekend, not rolled forward

--- a/tests/test_eurex_calendar.py
+++ b/tests/test_eurex_calendar.py
@@ -55,6 +55,25 @@ def test_pre_post_market_times():
     assert session.market_close == pd.Timestamp("2025-03-07 16:30", tz="UTC")
     assert session.post == pd.Timestamp("2025-03-07 21:00", tz="UTC")
 
+    early_close = eurex.schedule(
+        "2025-12-24",
+        "2025-12-24",
+        start="pre",
+        end="post",
+    ).loc["2025-12-24"]
+    assert early_close.market_close == pd.Timestamp("2025-12-24 11:30", tz="UTC")
+    assert early_close.post == pd.Timestamp("2025-12-24 11:30", tz="UTC")
+
+    post_only = eurex.schedule(
+        "2025-12-24",
+        "2025-12-24",
+        market_times=["post"],
+    ).loc["2025-12-24"]
+    assert post_only.post == pd.Timestamp("2025-12-24 11:30", tz="UTC")
+
+    special_post = eurex.special_dates("post", "2025-12-24", "2025-12-24")
+    assert special_post.loc[pd.Timestamp("2025-12-24")] == pd.Timestamp("2025-12-24 11:30", tz="UTC")
+
 
 def test_2016_holidays():
     # good friday: 2016-03-25

--- a/tests/test_eurex_calendar.py
+++ b/tests/test_eurex_calendar.py
@@ -1,7 +1,8 @@
 import pandas as pd
 from zoneinfo import ZoneInfo
 
-from pandas_market_calendars.calendars.eurex import EUREXExchangeCalendar
+from pandas_market_calendars import get_calendar
+from pandas_market_calendars.calendars.eurex import EUREXExchangeCalendar, EUREXPrePostExchangeCalendar
 
 
 def test_time_zone():
@@ -26,6 +27,33 @@ def test_regular_market_times():
     session = schedule.loc["2025-03-07"]
     assert session.market_open == pd.Timestamp("2025-03-07 08:00", tz=eurex.tz)
     assert session.market_close == pd.Timestamp("2025-03-07 22:00", tz=eurex.tz)
+
+
+def test_pre_post_market_times():
+    eurex = EUREXPrePostExchangeCalendar()
+
+    assert eurex.tz == ZoneInfo("UTC")
+    assert eurex.name == "EUREX_PrePost"
+    assert eurex.market_times == ["pre", "market_open", "market_close", "post"]
+    assert eurex.regular_market_times["pre"] == ((None, pd.Timestamp("00:15").time()),)
+    assert eurex.regular_market_times["market_open"] == ((None, pd.Timestamp("08:00").time()),)
+    assert eurex.regular_market_times["market_close"] == ((None, pd.Timestamp("16:30").time()),)
+    assert eurex.regular_market_times["post"] == ((None, pd.Timestamp("21:00").time()),)
+
+    assert get_calendar("EUREX_PrePost").name == "EUREX_PrePost"
+    assert get_calendar("EUREX_Extended").name == "EUREX_PrePost"
+
+    schedule = eurex.schedule(
+        "2025-03-07",
+        "2025-03-07",
+        start="pre",
+        end="post",
+    )
+    session = schedule.loc["2025-03-07"]
+    assert session.pre == pd.Timestamp("2025-03-07 00:15", tz="UTC")
+    assert session.market_open == pd.Timestamp("2025-03-07 08:00", tz="UTC")
+    assert session.market_close == pd.Timestamp("2025-03-07 16:30", tz="UTC")
+    assert session.post == pd.Timestamp("2025-03-07 21:00", tz="UTC")
 
 
 def test_2016_holidays():

--- a/tests/test_eurex_calendar.py
+++ b/tests/test_eurex_calendar.py
@@ -13,6 +13,8 @@ def test_regular_market_times():
     eurex = EUREXExchangeCalendar()
 
     assert "pre" not in eurex.regular_market_times
+    assert "post" not in eurex.regular_market_times
+    assert eurex.market_times == ["market_open", "market_close"]
     assert eurex.regular_market_times["market_open"] == ((None, pd.Timestamp("08:00").time()),)
     assert eurex.regular_market_times["market_close"] == ((None, pd.Timestamp("22:00").time()),)
 

--- a/tests/test_exchange_calendar_cme_globex_energy_and_metals.py
+++ b/tests/test_exchange_calendar_cme_globex_energy_and_metals.py
@@ -99,10 +99,11 @@ def test_new_years_sunday_is_observed_on_monday():
     assert pd.Timestamp("2023-01-03", tz="UTC") in valid_days
 
 
-def test_new_years_saturday_is_not_observed_on_monday():
-    valid_days = cal.valid_days("2010-12-31", "2011-01-04")
+def test_new_years_saturday_keeps_documented_2011_sessions():
+    schedule = cal.schedule("2010-12-31", "2011-01-04", tz=cal.tz)
 
-    assert pd.Timestamp("2011-01-03", tz="UTC") in valid_days
+    assert schedule.loc["2010-12-31"].market_close == pd.Timestamp("2010-12-31 15:15:00", tz=cal.tz)
+    assert schedule.loc["2011-01-03"].market_open == pd.Timestamp("2011-01-02 17:00:00", tz=cal.tz)
 
 
 def test_energy_and_metals_new_years_2021_closed_but_2022_monday_open():

--- a/tests/test_exchange_calendar_cme_globex_energy_and_metals.py
+++ b/tests/test_exchange_calendar_cme_globex_energy_and_metals.py
@@ -88,6 +88,10 @@ def _test_has_early_closes(early_closes, start, end):
 #########################################################################
 # YEARLY TESTS BEGIN
 #########################################################################
+# Regression source for CME Globex Energy and Metals New Year's behavior:
+# https://github.com/rsheftel/pandas_market_calendars/issues/340
+# Historical CME schedule showing Jan. 3, 2011 was open after a Saturday New Year's Day:
+# https://github.com/rsheftel/pandas_market_calendars/files/14588227/2011-new-years.pdf
 def test_new_years_sunday_is_observed_on_monday():
     valid_days = cal.valid_days("2022-12-30", "2023-01-04")
 
@@ -99,6 +103,14 @@ def test_new_years_saturday_is_not_observed_on_monday():
     valid_days = cal.valid_days("2010-12-31", "2011-01-04")
 
     assert pd.Timestamp("2011-01-03", tz="UTC") in valid_days
+
+
+def test_energy_and_metals_new_years_2021_closed_but_2022_monday_open():
+    valid_days = cal.valid_days("2020-12-31", "2022-01-04")
+
+    assert pd.Timestamp("2021-01-01", tz="UTC") not in valid_days
+    assert pd.Timestamp("2021-12-31", tz="UTC") in valid_days
+    assert pd.Timestamp("2022-01-03", tz="UTC") in valid_days
 
 
 def test_2022():

--- a/tests/test_exchange_calendar_cme_globex_energy_and_metals.py
+++ b/tests/test_exchange_calendar_cme_globex_energy_and_metals.py
@@ -88,6 +88,19 @@ def _test_has_early_closes(early_closes, start, end):
 #########################################################################
 # YEARLY TESTS BEGIN
 #########################################################################
+def test_new_years_sunday_is_observed_on_monday():
+    valid_days = cal.valid_days("2022-12-30", "2023-01-04")
+
+    assert pd.Timestamp("2023-01-02", tz="UTC") not in valid_days
+    assert pd.Timestamp("2023-01-03", tz="UTC") in valid_days
+
+
+def test_new_years_saturday_is_not_observed_on_monday():
+    valid_days = cal.valid_days("2010-12-31", "2011-01-04")
+
+    assert pd.Timestamp("2011-01-03", tz="UTC") in valid_days
+
+
 def test_2022():
     start = "2022-01-01"
     end = "2022-12-31"

--- a/tests/test_exchange_calendar_cme_globex_fixed_income.py
+++ b/tests/test_exchange_calendar_cme_globex_fixed_income.py
@@ -1,3 +1,5 @@
+from datetime import time
+
 import pandas as pd
 import pytest
 from pandas.tseries.offsets import Day, Hour, Minute
@@ -8,6 +10,13 @@ from pandas_market_calendars.calendars.cme_globex_fixed_income import (
 
 
 TZ = "America/Chicago"
+
+
+def test_regular_market_times():
+    under_test = CMEGlobexFixedIncomeCalendar()
+
+    assert under_test.regular_market_times["market_open"] == ((None, time(17), -1),)
+    assert under_test.regular_market_times["market_close"] == ((None, time(16)),)
 
 
 @pytest.mark.parametrize(
@@ -573,13 +582,13 @@ def test_2020_through_2022_and_prior_holidays(day_status):
 
     if expected_status == "open":
         s = schedule.loc[day_str]
-        assert s["market_open"] == day_ts + Day(-1) + Hour(18) + Minute(0)
-        assert s["market_close"] == day_ts + Day(0) + Hour(17) + Minute(0)
+        assert s["market_open"] == day_ts + Day(-1) + Hour(17) + Minute(0)
+        assert s["market_close"] == day_ts + Day(0) + Hour(16) + Minute(0)
     elif expected_status == "closed":
         assert day_ts.tz_localize(None) not in schedule.index
     else:
         s = schedule.loc[day_str]
         hour = int(expected_status[0:2])
         minute = int(expected_status[2:4])
-        assert s["market_open"] == day_ts + Day(-1) + Hour(18)
+        assert s["market_open"] == day_ts + Day(-1) + Hour(17)
         assert s["market_close"] == day_ts + Day(0) + Hour(hour) + Minute(minute)

--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_import_does_not_change_pandas_holiday_calendar_defaults():
+    code = textwrap.dedent(
+        """
+        import pandas as pd
+        from pandas.tseries.holiday import MO, AbstractHolidayCalendar, Holiday
+        from pandas.tseries.offsets import CustomBusinessDay
+
+        USMemorialDay = Holiday(
+            "Memorial Day", month=5, day=31, offset=pd.DateOffset(weekday=MO(-1))
+        )
+
+        class ExampleCalendar(AbstractHolidayCalendar):
+            rules = [USMemorialDay]
+
+        bday_before = CustomBusinessDay(calendar=ExampleCalendar())
+        baseline_start = AbstractHolidayCalendar.start_date
+        baseline_end = AbstractHolidayCalendar.end_date
+
+        import pandas_market_calendars
+
+        bday_after = CustomBusinessDay(calendar=ExampleCalendar())
+        assert bday_before == bday_after
+        assert AbstractHolidayCalendar.start_date == baseline_start
+        assert AbstractHolidayCalendar.end_date == baseline_end
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -22,9 +22,14 @@ def test_import_does_not_change_pandas_holiday_calendar_defaults():
         baseline_end = AbstractHolidayCalendar.end_date
 
         import pandas_market_calendars
+        from pandas_market_calendars.market_calendar import HolidayCalendar
 
+        bounded = HolidayCalendar(rules=[USMemorialDay], start_date="2010-01-01", end_date="2010-12-31")
+        bounded_holidays = bounded.holidays()
         bday_after = CustomBusinessDay(calendar=ExampleCalendar())
+
         assert bday_before == bday_after
+        assert bounded_holidays[0] == pd.Timestamp("2010-05-31")
         assert AbstractHolidayCalendar.start_date == baseline_start
         assert AbstractHolidayCalendar.end_date == baseline_end
         """

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -141,6 +141,14 @@ def test_valid_days_tz_aware():
     assert_index_equal(actual, expected)
 
 
+def test_holidays_rollback_uses_modern_weekmask():
+    nyse = NYSEExchangeCalendar()
+
+    assert nyse.holidays().rollback("2022-06-26") == pd.Timestamp("2022-06-24")
+    assert nyse.holidays().weekmask == "Mon Tue Wed Thu Fri"
+    assert nyse.holidays_pre_1952().weekmask == "Mon Tue Wed Thu Fri Sat"
+
+
 def test_time_zone():
     assert NYSEExchangeCalendar().tz == ZoneInfo("America/New_York")
     assert NYSEExchangeCalendar().name == "NYSE"
@@ -185,6 +193,20 @@ def test_2012():
     assert len(expected) == 3
     for early_close_session_label in early_closes_2012:
         assert early_close_session_label in expected.index
+
+
+def test_post_market_close_on_modern_early_close_days():
+    nyse = NYSEExchangeCalendar()
+    schedule = nyse.schedule(
+        "2019-12-24",
+        "2019-12-24",
+        market_times=["pre", "market_open", "market_close", "post"],
+        tz="America/New_York",
+    )
+
+    session = schedule.loc["2019-12-24"]
+    assert session.market_close == pd.Timestamp("2019-12-24 13:00", tz=nyse.tz)
+    assert session.post == pd.Timestamp("2019-12-24 17:00", tz=nyse.tz)
 
 
 def test_special_holidays():

--- a/tests/test_nyse_calendar.py
+++ b/tests/test_nyse_calendar.py
@@ -207,6 +207,8 @@ def test_post_market_close_on_modern_early_close_days():
     session = schedule.loc["2019-12-24"]
     assert session.market_close == pd.Timestamp("2019-12-24 13:00", tz=nyse.tz)
     assert session.post == pd.Timestamp("2019-12-24 17:00", tz=nyse.tz)
+    post_only = nyse.schedule("2019-12-24", "2019-12-24", market_times=["post"], tz="America/New_York")
+    assert post_only.loc["2019-12-24"].post == session.post
 
 
 def test_special_holidays():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,6 +88,8 @@ def test_merge_schedules_inner_excludes_reported_non_overlapping_session():
 
     actual = mcal.merge_schedules([nyse_schedule, xetra_schedule], how="inner")
 
+    assert not actual.empty
+    assert pd.Timestamp("2024-12-02") in actual.index
     assert pd.Timestamp("2024-12-30") not in actual.index
     assert (actual["market_open"] < actual["market_close"]).all()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,21 +65,11 @@ def test_merge_schedules():
     actual = mcal.merge_schedules([sch2, sch1], how="outer")
     assert_frame_equal(actual, expected)
 
-    # inner join will exclude July 4th because not open for both
-    expected = pd.DataFrame(
-        {
-            "market_open": [
-                pd.Timestamp(x, tz="UTC") for x in ["2016-07-01 13:30", "2016-07-05 13:30", "2016-07-06 13:30"]
-            ],
-            "market_close": [
-                pd.Timestamp(x, tz="UTC") for x in ["2016-07-01 02:49", "2016-07-05 02:49", "2016-07-06 02:49"]
-            ],
-        },
-        columns=["market_open", "market_close"],
-        index=pd.DatetimeIndex(["2016-07-01", "2016-07-05", "2016-07-06"]),
-    )
+    # inner join will exclude July 4th because cal2 is closed and exclude
+    # remaining days because the two schedules do not overlap intraday
     actual = mcal.merge_schedules([sch1, sch2], how="inner")
-    assert_frame_equal(actual, expected)
+    assert actual.empty
+    assert actual.columns.to_list() == ["market_open", "market_close"]
 
     # joining more than two calendars works correctly
     actual = mcal.merge_schedules([sch1, sch1, sch1], how="inner")
@@ -87,6 +77,19 @@ def test_merge_schedules():
 
     with pytest.raises(ValueError):
         mcal.merge_schedules([sch1, sch2], how="left")
+
+
+def test_merge_schedules_inner_excludes_reported_non_overlapping_session():
+    nyse = mcal.get_calendar("XNYS")
+    xetra = mcal.get_calendar("XETR")
+
+    nyse_schedule = nyse.schedule("2024-12-01", "2024-12-31")
+    xetra_schedule = xetra.schedule("2024-12-01", "2024-12-31")
+
+    actual = mcal.merge_schedules([nyse_schedule, xetra_schedule], how="inner")
+
+    assert pd.Timestamp("2024-12-30") not in actual.index
+    assert (actual["market_open"] < actual["market_close"]).all()
 
 
 def test_merge_schedules_w_break():


### PR DESCRIPTION
## Summary
- remove global pandas holiday-calendar start-date mutations while preserving local historical holiday bounds
- fix schedule merges that create non-overlapping inner intervals
- fix CME calendar regressions for Globex holidays, fixed-income hours, agriculture hours, and historical equity hours
- add explicit `CME_TradeDate` support for CME settlement/trade-date users while keeping `CME_Equity` schedule-day semantics intact
- fix NYSE early-close post-market handling, BSE/NSE aliases and 2024 election holiday, NYSE rollback behavior, and EUREX regular open/close hours
- add `EUREX_PrePost` / `EUREX_Extended` for the EUREX pre/post UTC session endpoints requested in #184 while keeping generic `EUREX` regular-hours-only
- document that calendars are package-shipped code, not live server-provided data
- harden date-specific market-time helpers so they use the same cutover/offset resolver as generated schedules

Fixes #207
Fixes #242
Fixes #244
Fixes #301
Fixes #340
Fixes #344
Fixes #355
Fixes #356
Fixes #382
Fixes #387
Fixes #441

Related #184
Related #343

## Source notes
- CME Globex Energy and Metals New Year's regression source: https://github.com/rsheftel/pandas_market_calendars/issues/340
- Historical CME New Year's 2011 schedule PDF showing Monday Jan. 3 open after Saturday New Year's Day: https://github.com/rsheftel/pandas_market_calendars/files/14588227/2011-new-years.pdf
- #184 is related, not auto-closed: `EUREX_PrePost` / `EUREX_Extended` provides the requested UTC endpoints, but the original issue asks about generic `EUREX`; generic `EUREX` remains regular-hours-only to satisfy #382.
- #343 is related, not auto-closed: this PR adds an explicit `CME_TradeDate` calendar for trade-date users, but keeps `CME_Equity.valid_days()` aligned with schedule/session days to preserve the base API contract and avoid dropping real early-close sessions.

## Tests
- `uv run --no-sync pytest -q`
- `uv run --no-sync pytest -q tests/test_eurex_calendar.py tests/test_cme_equity_calendar.py tests/test_cme_agriculture_calendar.py tests/test_exchange_calendar_cme_globex_grains.py tests/test_nyse_calendar.py tests/test_import_side_effects.py`
- `uv run --no-sync ruff check <changed files>`
- `git diff --check`