### PR TITLE
Correct CME Energy and Metals early closes for 2026

### DIFF
--- a/.github/plans/issue_464_cme_2026_early_closes.md
+++ b/.github/plans/issue_464_cme_2026_early_closes.md
@@ -1,0 +1,24 @@
+# Issue 464 CME 2026 Early-Close Plan
+
+## Current Step
+
+4. Run the focused calendar tests, formatter, and diff checks. Completed.
+
+## Plan
+
+1. Reproduce the five reported close times on the current `dev` branch and identify the holiday rules that emit them. Completed.
+2. Add 2026-only holiday rules so the correction doesn't change other calendar years. Completed.
+3. Add focused regression coverage through the public `CMEGlobex_GC` and `CMEGlobex_MCL` aliases. Completed.
+4. Run the focused calendar tests, formatter, and diff checks. Completed.
+
+## Assumptions
+
+- The five dates and close times reported in issue #464 are the authoritative 2026 values.
+- This change applies only to the Energy and Metals calendar family.
+
+## Validation
+
+- Energy and Metals test file: 12 passed.
+- CME Globex calendar test files: 1070 passed.
+- Ruff formatting and lint checks passed for the changed Python files.
+- The full fast suite reached 1254 passing tests before stopping at the existing timezone-sensitive `test_valid_days_tz_aware` assertion in `tests/test_nyse_calendar.py`.

--- a/pandas_market_calendars/calendars/cme_globex_energy_and_metals.py
+++ b/pandas_market_calendars/calendars/cme_globex_energy_and_metals.py
@@ -22,12 +22,16 @@ from zoneinfo import ZoneInfo
 
 from pandas_market_calendars.holidays.cme_globex import (
     ChristmasCME,
-    FridayAfterThanksgiving,
+    FridayAfterThanksgivingFrom2027,
+    FridayAfterThanksgivingThrough2025,
     GoodFriday,
-    USIndependenceDayFrom2022,
+    USIndependenceDayFrom2022Through2025,
+    USIndependenceDayFrom2027,
     USIndependenceDayPre2022,
-    USJuneteenthFrom2022,
-    USLaborDay,
+    USJuneteenthFrom2022Through2025,
+    USJuneteenthFrom2027,
+    USLaborDayFrom2027,
+    USLaborDayThrough2025,
     USMartinLutherKingJrFrom2022,
     USMartinLutherKingJrPre2022,
     USMemorialDayFrom2022,
@@ -192,7 +196,8 @@ class CMEGlobexEnergyAndMetalsExchangeCalendar(CMEGlobexBaseExchangeCalendar):
                         USPresidentsDayPre2022,
                         USMemorialDayPre2022,
                         USIndependenceDayPre2022,
-                        USLaborDay,
+                        USLaborDayThrough2025,
+                        USLaborDayFrom2027,
                         USThanksgivingDayPre2022,
                     ]
                 ),
@@ -201,7 +206,8 @@ class CMEGlobexEnergyAndMetalsExchangeCalendar(CMEGlobexBaseExchangeCalendar):
                 time(12, 45),
                 AbstractHolidayCalendar(
                     rules=[
-                        FridayAfterThanksgiving,
+                        FridayAfterThanksgivingThrough2025,
+                        FridayAfterThanksgivingFrom2027,
                     ]
                 ),
             ),
@@ -212,8 +218,10 @@ class CMEGlobexEnergyAndMetalsExchangeCalendar(CMEGlobexBaseExchangeCalendar):
                         USMartinLutherKingJrFrom2022,
                         USPresidentsDayFrom2022,
                         USMemorialDayFrom2022,
-                        USJuneteenthFrom2022,
-                        USIndependenceDayFrom2022,
+                        USJuneteenthFrom2022Through2025,
+                        USJuneteenthFrom2027,
+                        USIndependenceDayFrom2022Through2025,
+                        USIndependenceDayFrom2027,
                         USThanksgivingDayFrom2022,
                     ]
                 ),
@@ -224,7 +232,23 @@ class CMEGlobexEnergyAndMetalsExchangeCalendar(CMEGlobexBaseExchangeCalendar):
     def special_closes_adhoc(self) -> List[Any]:
         return [
             (
+                time(12),
+                ["2026-06-19", "2026-07-03"],
+            ),
+            (
+                time(12, 45),
+                ["2026-12-24"],
+            ),
+            (
+                time(13, 30),
+                ["2026-09-07"],
+            ),
+            (
+                time(13, 45),
+                ["2026-11-27"],
+            ),
+            (
                 time(15, 15),
                 ["2010-12-31"],
-            )
+            ),
         ]

--- a/pandas_market_calendars/holidays/cme_globex.py
+++ b/pandas_market_calendars/holidays/cme_globex.py
@@ -118,6 +118,23 @@ USJuneteenthFrom2022 = Holiday(
     observance=nearest_workday,
 )
 
+USJuneteenthFrom2022Through2025 = Holiday(
+    "Juneteenth Starting at 2022",
+    start_date=Timestamp("2022-06-19"),
+    end_date=Timestamp("2025-12-31"),
+    month=6,
+    day=19,
+    observance=nearest_workday,
+)
+
+USJuneteenthFrom2027 = Holiday(
+    "Juneteenth Starting at 2027",
+    start_date=Timestamp("2027-01-01"),
+    month=6,
+    day=19,
+    observance=nearest_workday,
+)
+
 #######################################
 # US Independence Day July 4
 #######################################
@@ -126,6 +143,21 @@ USIndependenceDayFrom2022 = Holiday(
     month=7,
     day=4,
     start_date=Timestamp("2022-01-01"),
+    observance=nearest_workday,
+)
+USIndependenceDayFrom2022Through2025 = Holiday(
+    "July 4th",
+    month=7,
+    day=4,
+    start_date=Timestamp("2022-01-01"),
+    end_date=Timestamp("2025-12-31"),
+    observance=nearest_workday,
+)
+USIndependenceDayFrom2027 = Holiday(
+    "July 4th",
+    month=7,
+    day=4,
+    start_date=Timestamp("2027-01-01"),
     observance=nearest_workday,
 )
 USIndependenceDayPre2022 = Holiday(
@@ -160,6 +192,21 @@ USLaborDay = Holiday(
     start_date=Timestamp("1887-01-01"),
     offset=DateOffset(weekday=MO(1)),
 )
+USLaborDayThrough2025 = Holiday(
+    "Labor Day",
+    month=9,
+    day=1,
+    start_date=Timestamp("1887-01-01"),
+    end_date=Timestamp("2025-12-31"),
+    offset=DateOffset(weekday=MO(1)),
+)
+USLaborDayFrom2027 = Holiday(
+    "Labor Day",
+    month=9,
+    day=1,
+    start_date=Timestamp("2027-01-01"),
+    offset=DateOffset(weekday=MO(1)),
+)
 
 ################################################
 # US Thanksgiving Nov 30
@@ -184,6 +231,22 @@ FridayAfterThanksgiving = Holiday(
     "Friday after Thanksgiving",
     month=11,
     day=1,
+    offset=[DateOffset(weekday=TH(4)), Day(1)],
+)
+
+FridayAfterThanksgivingThrough2025 = Holiday(
+    "Friday after Thanksgiving",
+    month=11,
+    day=1,
+    end_date=Timestamp("2025-12-31"),
+    offset=[DateOffset(weekday=TH(4)), Day(1)],
+)
+
+FridayAfterThanksgivingFrom2027 = Holiday(
+    "Friday after Thanksgiving",
+    month=11,
+    day=1,
+    start_date=Timestamp("2027-01-01"),
     offset=[DateOffset(weekday=TH(4)), Day(1)],
 )
 

--- a/tests/test_exchange_calendar_cme_globex_energy_and_metals.py
+++ b/tests/test_exchange_calendar_cme_globex_energy_and_metals.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pandas.testing import assert_index_equal
 from zoneinfo import ZoneInfo
 
+import pandas_market_calendars as mcal
 from pandas_market_calendars.calendars.cme_globex_energy_and_metals import (
     CMEGlobexEnergyAndMetalsExchangeCalendar,
 )
@@ -83,6 +84,44 @@ def _test_has_early_closes(early_closes, start, end):
     assert len(expected) == len(early_closes)
     for ts in early_closes:
         assert _test_verify_early_close_time(schedule, ts) is True
+
+
+# Reported against CME's published 2026 Energy and Metals schedule:
+# https://github.com/rsheftel/pandas_market_calendars/issues/464
+def test_2026_energy_and_metals_early_closes():
+    expected_closes = {
+        "2026-06-19": pd.Timestamp("2026-06-19 13:00", tz="America/New_York"),
+        "2026-07-03": pd.Timestamp("2026-07-03 13:00", tz="America/New_York"),
+        "2026-09-07": pd.Timestamp("2026-09-07 14:30", tz="America/New_York"),
+        "2026-11-27": pd.Timestamp("2026-11-27 14:45", tz="America/New_York"),
+        "2026-12-24": pd.Timestamp("2026-12-24 13:45", tz="America/New_York"),
+    }
+
+    for alias in ("CMEGlobex_GC", "CMEGlobex_MCL"):
+        calendar = mcal.get_calendar(alias)
+        schedule = calendar.schedule("2026-06-19", "2026-12-24", tz="America/New_York")
+
+        for session, expected_close in expected_closes.items():
+            actual_close = schedule.at[pd.Timestamp(session), "market_close"]
+            assert actual_close == expected_close, f"{alias} {session}"
+
+
+def test_2026_overrides_preserve_neighboring_year_rules():
+    expected_closes = {
+        "2025-06-19": pd.Timestamp("2025-06-19 14:30", tz="America/New_York"),
+        "2027-06-18": pd.Timestamp("2027-06-18 14:30", tz="America/New_York"),
+        "2025-07-04": pd.Timestamp("2025-07-04 14:30", tz="America/New_York"),
+        "2027-07-05": pd.Timestamp("2027-07-05 14:30", tz="America/New_York"),
+        "2025-09-01": pd.Timestamp("2025-09-01 13:00", tz="America/New_York"),
+        "2027-09-06": pd.Timestamp("2027-09-06 13:00", tz="America/New_York"),
+        "2025-11-28": pd.Timestamp("2025-11-28 13:45", tz="America/New_York"),
+        "2027-11-26": pd.Timestamp("2027-11-26 13:45", tz="America/New_York"),
+    }
+    schedule = cal.schedule("2025-06-19", "2027-11-26", tz="America/New_York")
+
+    for session, expected_close in expected_closes.items():
+        actual_close = schedule.at[pd.Timestamp(session), "market_close"]
+        assert actual_close == expected_close, session
 
 
 #########################################################################


### PR DESCRIPTION
Fixes #464.

The five reported 2026 CME Energy and Metals closes don't fit the current recurring rules. The recurring calendars now skip those dates, with the reported times added as date-specific closes. The existing rules stay in place for earlier and later years.

Tests:
- focused Energy and Metals tests: 12 passed
- related CME Globex tests: 1070 passed
- Ruff format and lint checks passed

The fast suite reached 1254 passing tests before the existing timezone-sensitive NYSE assertion failed.