### PR TITLE
HKEX: add 2026-04-07 holiday (day following Easter Monday)

### DIFF
--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Unreleased
+~~~~~~~~~~
+- Fix HKEX incorrectly treating 2026-04-07 as a trading day; it is a Hong Kong general holiday ("the day following Easter Monday", observed because the Ching Ming Festival substitute fell on Easter Monday)
+
+  Fixes #467
+
 5.4.0 (05/25/2026)
 ~~~~~~~~~~~~~~~~~~
 - PR #462 to fix numerous issues

--- a/pandas_market_calendars/calendars/hkex.py
+++ b/pandas_market_calendars/calendars/hkex.py
@@ -354,6 +354,7 @@ HKClosedDay = [
     Timestamp("2023-07-17", tz="UTC"),  # Typhoon closure
     Timestamp("2023-09-01", tz="UTC"),  # Typhoon closure
     Timestamp("2023-09-08", tz="UTC"),  # Typhoon closure
+    Timestamp("2026-04-07", tz="UTC"),  # 复活节+清明节补假 (day following Easter Monday)
 ]
 
 

--- a/tests/test_hkex_calendar.py
+++ b/tests/test_hkex_calendar.py
@@ -39,6 +39,15 @@ def test_2018_holidays():
         assert pd.Timestamp(date, tz="UTC") in trading_days
 
 
+def test_2026_day_following_easter_monday():
+    # In 2026 the day following the Ching Ming Festival substitute falls on
+    # Easter Monday, so 2026-04-07 (Tue) is an additional general holiday and
+    # the exchange is closed. See issue #467.
+    hkex = HKEXExchangeCalendar()
+    trading_days = hkex.valid_days("2026-04-01", "2026-04-30")
+    assert pd.Timestamp("2026-04-07", tz="UTC") not in trading_days
+
+
 def test_hkex_closes_at_lunch():
     hkex = HKEXExchangeCalendar()
     schedule = hkex.schedule(


### PR DESCRIPTION
Fixes #467

### Problem

The HKEX calendar treats **2026-04-07 (Tue)** as a trading day, but the Hong Kong market is closed that day.

In 2026 the Ching Ming Festival falls on Sunday 5 April, so its substitute is Monday 6 April — which coincides with Easter Monday. Under HK's rules, when a general holiday's substitute lands on another general holiday, the next non-holiday day becomes an additional general holiday. That day is **Tuesday 7 April 2026** ("the day following Easter Monday"), producing a five-day break (Good Friday 3 Apr → Tue 7 Apr).

Verified before/after:

```python
import pandas_market_calendars as mcal
days = mcal.get_calendar("HKEX").schedule("2026-04-01", "2026-04-10").index
# before: 2026-04-07 present (trading);  after: absent (closed)
```

### Fix

Add `Timestamp("2026-04-07", tz="UTC")` to `HKClosedDay`, mirroring the existing `2015-04-07` entry (the same Easter/Ching Ming collision).

### Source

Official HK government general holidays 2026: https://www.gov.hk/en/about/abouthk/holiday/2026.htm — lists "The day following Easter Monday – April 7, 2026 (Tuesday)".

### Tests

Added `test_2026_day_following_easter_monday`, which fails on `master` and passes with this change; the full `tests/test_hkex_calendar.py` passes (4 passed). Changelog updated.