### PR TITLE
HKEX: add 2026-04-07 compensatory holiday (Easter Monday / Ching Ming overlap)

### DIFF
--- a/pandas_market_calendars/calendars/hkex.py
+++ b/pandas_market_calendars/calendars/hkex.py
@@ -354,6 +354,9 @@ HKClosedDay = [
     Timestamp("2023-07-17", tz="UTC"),  # Typhoon closure
     Timestamp("2023-09-01", tz="UTC"),  # Typhoon closure
     Timestamp("2023-09-08", tz="UTC"),  # Typhoon closure
+    # 2026: Ching Ming substitute (Apr 6) coincides with Easter Monday,
+    # so Apr 7 is an additional general holiday (same pattern as 2015-04-07)
+    Timestamp("2026-04-07", tz="UTC"),
 ]
 
 

--- a/tests/test_hkex_calendar.py
+++ b/tests/test_hkex_calendar.py
@@ -39,6 +39,18 @@ def test_2018_holidays():
         assert pd.Timestamp(date, tz="UTC") in trading_days
 
 
+def test_2026_easter_ching_ming_overlap():
+    # Ching Ming 2026 falls on Sunday Apr 5; its substitute (Mon Apr 6)
+    # coincides with Easter Monday, so Tue Apr 7 is an additional general
+    # holiday and HKEX is closed.
+    hkex = HKEXExchangeCalendar()
+    trading_days = hkex.valid_days("2026-04-01", "2026-04-10")
+    for date in ["2026-04-03", "2026-04-06", "2026-04-07"]:
+        assert pd.Timestamp(date, tz="UTC") not in trading_days
+    for date in ["2026-04-01", "2026-04-02", "2026-04-08"]:
+        assert pd.Timestamp(date, tz="UTC") in trading_days
+
+
 def test_hkex_closes_at_lunch():
     hkex = HKEXExchangeCalendar()
     schedule = hkex.schedule(


### PR DESCRIPTION
## Summary
HKEX is closed on Tuesday 2026-04-07, but the calendar currently returns it as a trading day.

Per the [HK Government's 2026 general holidays](https://www.gov.hk/en/about/abouthk/holiday/2026.htm): Ching Ming 2026 falls on a Sunday (Apr 5), so the following day (Mon Apr 6) is its substitute — but that day is also Easter Monday, so "the next day that is not itself a general holiday" (Tue Apr 7) is gazetted as an additional general holiday. The [HKEX calendar](https://www.hkex.com.hk/News/HKEX-Calendar?sc_lang=en&datefrom=2026-04-07) confirms Apr 7 is a non-trading day.

This is the same Easter/Ching Ming overlap pattern as 2015-04-07, which is already in `HKClosedDay`.

Fixes #467.

## Changes
- Added `2026-04-07` to `HKClosedDay` (next to the analogous 2015 entry).
- New test `test_2026_easter_ching_ming_overlap` asserting Apr 3/6/7 are closed and Apr 1/2/8 are trading days.

## Before / after
```
>>> mcal.get_calendar('HKEX').schedule('2026-04-01', '2026-04-10').index
before: 04-01, 04-02, 04-07, 04-08, 04-09, 04-10
after:  04-01, 04-02, 04-08, 04-09, 04-10
```

`tests/test_hkex_calendar.py` passes.
