### PR TITLE
LSE: keep 2022-05-30 open — spring bank holiday was moved for the Platinum Jubilee

### DIFF
--- a/pandas_market_calendars/holidays/uk.py
+++ b/pandas_market_calendars/holidays/uk.py
@@ -58,7 +58,7 @@ MayBank_post_2020 = Holiday(
 # Spring bank holiday has two exceptions based on the Golden & Diamond Jubilee
 # 2002-05-27 Spring bank holiday removed for Golden Jubilee
 # 2012-05-28 Spring bank holiday removed for Diamond Jubilee
-# 2022-05-31 Spring bank holiday removed for Platinum Jubilee
+# 2022-05-30 Spring bank holiday removed for Platinum Jubilee (moved to 2022-06-02)
 
 # Spring bank holiday
 SpringBank_pre_2002 = Holiday(
@@ -92,7 +92,9 @@ SpringBank_post_2022 = Holiday(
     month=5,
     day=31,
     offset=DateOffset(weekday=MO(-1)),
-    start_date=Timestamp("2022-01-01"),
+    # 2022's holiday was moved to Jun 2 for the Platinum Jubilee (see the
+    # UniqueCloses entries), so this rule skips 2022 like 2002/2012 above
+    start_date=Timestamp("2023-01-01"),
 )
 
 # Summer bank holiday

--- a/tests/test_lse_calendar.py
+++ b/tests/test_lse_calendar.py
@@ -67,6 +67,7 @@ def test_unique_holidays():
         "QEII_Jubilee_25",
         "QEII_Jubilee_50",
         "QEII_Jubilee_60",
+        "QEII_Jubilee_70",
         "QEII_StateFuneral",
         "Royal_Wedding_Anne_1973",
         "Royal_Wedding_Charles_1981",
@@ -101,12 +102,14 @@ def test_unique_holidays():
         pd.Timestamp("2012-06-05"),
     ]
     england_unique_hols["QEII_Jubilee_60"]["open"] = [pd.Timestamp("2012-05-28")]  # Spring bank holiday removed
-    # Platinum Jubilee
-    england_unique_hols["QEII_Jubilee_60"]["closed"] = [
+    # Platinum Jubilee (NOTE: previously reused the QEII_Jubilee_60 key,
+    # overwriting the Diamond Jubilee entries above, and checked Tue
+    # 2022-05-31 instead of the moved spring bank holiday Mon 2022-05-30)
+    england_unique_hols["QEII_Jubilee_70"]["closed"] = [
         pd.Timestamp("2022-06-02"),
         pd.Timestamp("2022-06-03"),
     ]
-    england_unique_hols["QEII_Jubilee_60"]["open"] = [pd.Timestamp("2022-05-31")]  # Spring bank holiday removed
+    england_unique_hols["QEII_Jubilee_70"]["open"] = [pd.Timestamp("2022-05-30")]  # Spring bank holiday removed
 
     # State Funeral of Queen Elizabeth II
     england_unique_hols["QEII_StateFuneral"]["closed"] = [pd.Timestamp("2022-09-19")]


### PR DESCRIPTION
## Summary
LSE traded on Monday 2022-05-30, but the calendar closes it.

The UK's 2022 spring bank holiday was moved from the last Monday of May to Thursday 2 June for the Platinum Jubilee (with Friday 3 June as the extra Jubilee holiday) — both of which this repo already handles via `UniqueCloses`. However, `SpringBank_post_2022` starts at `2022-01-01`, so the generic last-Monday-of-May rule still fires for 2022-05-30. The 2002 (Golden) and 2012 (Diamond) Jubilee years are correctly skipped by the surrounding rules' start/end dates; 2022 should follow the same pattern. (Also reported in the #467 discussion.)

## Changes
- `SpringBank_post_2022` now starts `2023-01-01`, mirroring how 2002/2012 are skipped.
- Corrected the comment above the rules (2022's removed spring bank holiday was Mon 05-30, not 05-31).
- Fixed two latent problems in `test_unique_holidays` that let this slip through:
  - the Platinum Jubilee block reused the `"QEII_Jubilee_60"` key, silently **overwriting the Diamond Jubilee assertions** so the 2012 dates were never actually tested;
  - the "open" check used 2022-05-**31** (a Tuesday, trivially open) instead of the moved holiday Monday 2022-05-**30**.

  With the new `"QEII_Jubilee_70"` key both Jubilees are asserted, and the 05-30 check is a real regression test for this fix.

## Before / after
```
>>> mcal.get_calendar('LSE').schedule('2022-05-27', '2022-06-06').index
before: 05-27, 05-31, 06-01, 06-06          (05-30 wrongly closed)
after:  05-27, 05-30, 05-31, 06-01, 06-06   (06-02/03 Jubilee closures kept)
```

`tests/test_lse_calendar.py` passes.
