### PR TITLE
Fix for cloudpickle corrupting global registry

### DIFF
--- a/pandas_market_calendars/calendars/mirror.py
+++ b/pandas_market_calendars/calendars/mirror.py
@@ -148,15 +148,16 @@ for exchange in calendars:
         regular_market_times[new] = times
 
     cal = type(
-        exchange,
+        f"{exchange}ExchangeCalendar",
         (TradingCalendar,),
         {
+            "__module__": __name__,
             "_ec_class": calendars[exchange],
-            "alias": [exchange],
+            "aliases": [exchange],
             "regular_market_times": regular_market_times,
         },
     )
-    locals()[f"{exchange}ExchangeCalendar"] = cal
+    locals()[cal.__name__] = cal
 
 
 class XTAEExchangeCalendar(TradingCalendar):

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -1462,11 +1462,27 @@ test_cal = TstExchangeCalendar()
 
 
 def test_mirror():
-    assert not hasattr(mcal_iepa, "aliases")
+    assert mcal_iepa.aliases == ["IEPA"]
 
     assert not isinstance(ecal_iepa, mcal_iepa.__class__)
 
     assert isinstance(ecal_iepa, mcal_iepa._ec.__class__)
+
+
+def test_mirror_cloudpickle_round_trip_preserves_registry():
+    cloudpickle = pytest.importorskip("cloudpickle")
+    registry = MarketCalendar._regmeta_class_registry
+    original_calendar_class = registry["XLON"]
+
+    try:
+        calendar = get_calendar("XLON")
+        restored = cloudpickle.loads(cloudpickle.dumps(calendar))
+
+        assert restored.name == calendar.name == "XLON"
+        assert type(restored) is type(calendar)
+        assert type(get_calendar("XLON")) is type(calendar)
+    finally:
+        registry["XLON"] = original_calendar_class
 
 
 def test_basic_information():


### PR DESCRIPTION
## Problem

See Issue #475.

`calendars/mirror.py` creates calendar classes dynamically. Previously, an exchange such as `XLON` produced a class named `XLON`, then exported that class from the module as `XLONExchangeCalendar`. 

That mismatch meant the class did not have a stable importable module/name pair. Cloudpickle therefore serialized it by value. During deserialization, Cloudpickle reconstructed the class through `MarketCalendarMeta`, whose registration side effect replaced the valid `XLON` registry entry with an incomplete class before reconstruction finished. The restored instance still worked, but a later `get_calendar("XLON")` failed because the registry entry no longer had `_ec_class`.

## Changes in `mirror.py`

- Name each generated class after its exported symbol, for example `XLONExchangeCalendar` instead of `XLON`.
- Set `__module__` to `pandas_market_calendars.calendars.mirror` through `__name__`.
- Replace the ignored singular `alias` with `aliases = [exchange]` so the registry continues to use public exchange keys such as `XLON`, `XPAR`, and `IEPA` after the generated Python class names gain the `ExchangeCalendar` suffix.
- Export each class with `locals()[cal.__name__]`, keeping the module attribute exactly aligned with the class name Cloudpickle resolves.

Together, the generated class is now importable as:

```python
pandas_market_calendars.calendars.mirror.XLONExchangeCalendar
```

Cloudpickle can serialize that class by reference, so deserialization no longer creates a temporary class that mutates the global registry.

## Compatibility

- `get_calendar()` signatures and exchange lookup names are unchanged.
- Mirrored calendar behavior is unchanged.
- Generated class names now match their existing exported symbols.
- Runtime and CI dependencies are unchanged.

## Validation

- The CI workflow is unchanged; the regression skips when Cloudpickle is unavailable.
- The full non-slow test suite passes: 1,490 tests.