### PR TITLE
Fix CME equity market pause cutover

### DIFF
--- a/.github/plans/issue_477_cme_equity_market_pause.md
+++ b/.github/plans/issue_477_cme_equity_market_pause.md
@@ -1,0 +1,28 @@
+# Issue 477 CME Equity Market Pause Plan
+
+## Current Step
+
+4. Run focused plus full validation. Completed.
+
+## Plan
+
+1. Reproduce the obsolete post-cutover pause and confirm the historical boundary. Completed.
+2. Add focused schedule, open-state, and intraday-grid regression tests around the cutover. Completed.
+3. Add a date-effective CME equity-hours transition that preserves the pre-2021 pause. Completed.
+4. Run focused plus full validation. Completed.
+
+## Assumptions
+
+- CME's June 2021 Globex notice is authoritative for the June 28, 2021 trade-date cutover.
+- Historical sessions before the cutover must retain the 15:15-15:30 CT pause.
+- A zero-length break at the former 15:15 CT pause boundary preserves the established schedule schema without
+  removing any tradable time.
+
+## Validation
+
+- The two new regression tests failed before the implementation and passed afterward.
+- Focused CME equity and source tests: 25 passed.
+- Fast suite: 1492 passed and 1 failed; the only failure was the existing timezone-sensitive
+  `test_valid_days_tz_aware` NYSE baseline already documented on `dev`.
+- Ruff lint and format checks passed for all changed Python files.
+- `git diff --check` passed with CRLF treated as a valid line ending.

--- a/pandas_market_calendars/calendars/cme.py
+++ b/pandas_market_calendars/calendars/cme.py
@@ -60,6 +60,7 @@ from pandas_market_calendars.market_calendar import MarketCalendar
 
 CME_EQUITY_LEGACY_HOURS_START = "2005-09-12"
 CME_EQUITY_MODERN_HOURS_START = "2012-11-19"
+CME_EQUITY_MARKET_PAUSE_END = "2021-06-28"
 
 
 class CMETradeDateCalendar(MarketCalendar):
@@ -117,7 +118,8 @@ class CMEEquityExchangeCalendar(MarketCalendar):
 
     Open Time: 5:00 PM, America/Chicago
     Close Time: 4:00 PM, America/Chicago
-    Break: 3:15 - 3:30pm America/Chicago
+    Market pause through June 25, 2021: 3:15 - 3:30pm America/Chicago
+    No intraday pause from trade date June 28, 2021
     """
 
     aliases = ["CME_Equity", "CBOT_Equity"]
@@ -141,6 +143,8 @@ class CMEEquityExchangeCalendar(MarketCalendar):
             (None, time(15, 30)),
             (CME_EQUITY_LEGACY_HOURS_START, time(15, 15)),
             (CME_EQUITY_MODERN_HOURS_START, time(15, 30)),
+            # Preserve the schedule columns while representing continuous trading.
+            (CME_EQUITY_MARKET_PAUSE_END, time(15, 15)),
         ),
     }
 

--- a/pandas_market_calendars/sources.py
+++ b/pandas_market_calendars/sources.py
@@ -151,6 +151,12 @@ CALENDAR_SOURCES: dict[str, tuple[Source, ...]] = {
             last_verified="2025-01-24",
             covers="trading hours",
         ),
+        Source(
+            name="CME Globex Equity Market Pause Elimination Notice",
+            url="https://www.cmegroup.com/notices/electronic-trading/2021/06/20210621.html",
+            last_verified="2026-08-12",
+            covers="historical trading hours",
+        ),
     ),
     "CME_Agriculture": (
         Source(

--- a/tests/test_cme_equity_calendar.py
+++ b/tests/test_cme_equity_calendar.py
@@ -1,6 +1,9 @@
+from datetime import time
+
 import pandas as pd
 from zoneinfo import ZoneInfo
 
+import pandas_market_calendars as mcal
 from pandas_market_calendars.calendars.cme import CMEEquityExchangeCalendar, CMETradeDateCalendar
 
 
@@ -90,6 +93,34 @@ def test_historical_trade_date_time_helpers_match_schedule_cutovers():
     assert cme.close_time_on("2012-11-19").hour == 16
     assert cme.break_end_on("2012-11-19").hour == 15
     assert cme.break_end_on("2012-11-19").minute == 30
+
+
+def test_equity_market_pause_eliminated_on_june_28_2021():
+    cme = CMEEquityExchangeCalendar()
+    schedule = cme.schedule("2021-06-25", "2021-06-28", tz=cme.tz)
+
+    before_cutover = schedule.loc["2021-06-25"]
+    after_cutover = schedule.loc["2021-06-28"]
+
+    assert before_cutover.break_start == pd.Timestamp("2021-06-25 15:15:00", tz=cme.tz)
+    assert before_cutover.break_end == pd.Timestamp("2021-06-25 15:30:00", tz=cme.tz)
+    assert after_cutover.break_start == after_cutover.break_end
+    assert after_cutover.break_end == pd.Timestamp("2021-06-28 15:15:00", tz=cme.tz)
+    assert cme.break_end_on("2021-06-25") == time(15, 30)
+    assert cme.break_end_on("2021-06-28") == time(15, 15)
+
+    assert cme.open_at_time(schedule, "2021-06-25 15:20:00-05:00") is False
+    assert cme.open_at_time(schedule, "2021-06-28 15:20:00-05:00") is True
+
+
+def test_equity_market_pause_cutover_preserves_intraday_bars():
+    cme = CMEEquityExchangeCalendar()
+    schedule = cme.schedule("2021-06-25", "2021-06-28", tz=cme.tz)
+    bars = mcal.date_range(schedule, "5min")
+
+    for minute in (20, 25, 30):
+        assert pd.Timestamp(f"2021-06-25 15:{minute}:00", tz=cme.tz) not in bars
+        assert pd.Timestamp(f"2021-06-28 15:{minute}:00", tz=cme.tz) in bars
 
 
 def test_2023_good_friday_has_early_close_session():


### PR DESCRIPTION
## Summary

- stop emitting the obsolete 15:15-15:30 CT CME equity market pause from trade date June 28, 2021
- preserve the historical pause through June 25 and retain the existing schedule schema with a zero-length post-cutover break
- add the official CME notice as source provenance and cover schedule boundaries, open-state queries, and 5-minute bar generation

## Why

`CME_Equity` currently marks the market closed during the former pause on modern sessions. Besides making `open_at_time()` incorrect, this drops the 15:20, 15:25, and 15:30 bars from a 5-minute RTH grid after CME moved to continuous 5pm-4pm CT trading.

The date-effective `break_end` transition keeps pre-cutover backtests historically accurate while restoring every tradable post-cutover interval.

## Validation

- regression tests confirmed red before the implementation and green afterward
- `pytest -q tests/test_cme_equity_calendar.py tests/test_sources.py`: 25 passed
- `pytest -q -m "not slow"`: 1492 passed, 1 existing timezone-sensitive NYSE baseline failure (`test_valid_days_tz_aware`) already documented on `dev`
- Ruff lint and format checks passed for all changed Python files
- `git diff --check` passed with CRLF treated as a valid line ending

Fixes #477
