### PR TITLE
SIX: do not roll New Year's Eve back to the preceding Friday

### DIFF
--- a/pandas_market_calendars/calendars/six.py
+++ b/pandas_market_calendars/calendars/six.py
@@ -8,7 +8,6 @@ from pandas.tseries.holiday import (
     EasterMonday,
     GoodFriday,
     Holiday,
-    previous_friday,
 )
 from zoneinfo import ZoneInfo
 
@@ -27,7 +26,7 @@ NewYearsEve = Holiday(
     "New Year's Eve",
     month=12,
     day=31,
-    observance=previous_friday,
+    days_of_week=(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY),
 )
 # New Year's Day
 NewYearsDay = Holiday(

--- a/tests/test_six_calendar.py
+++ b/tests/test_six_calendar.py
@@ -77,3 +77,24 @@ def test_boxing_day_weekend():
         assert pd.Timestamp(date, tz="Europe/Berlin") in good_dates
     for date in ["2020-12-24", "2020-12-25", "2020-12-26", "2020-12-27"]:
         assert pd.Timestamp(date, tz="Europe/Zurich") not in good_dates
+
+
+def test_new_years_eve_weekend():
+    # new year's eve (observed): on a weekend, not rolled back to the Friday
+    six = SIXExchangeCalendar()
+
+    # 2022-12-31 is a Saturday, so 2022-12-30 is an ordinary trading day
+    good_dates = six.valid_days("2022-12-01", "2022-12-31", tz="Europe/Zurich")
+    for date in ["2022-12-29", "2022-12-30"]:
+        assert pd.Timestamp(date, tz="Europe/Zurich") in good_dates
+    for date in ["2022-12-24", "2022-12-25", "2022-12-26"]:
+        assert pd.Timestamp(date, tz="Europe/Zurich") not in good_dates
+
+    # 2023-12-31 is a Sunday, so 2023-12-29 is an ordinary trading day
+    good_dates = six.valid_days("2023-12-01", "2023-12-31", tz="Europe/Zurich")
+    for date in ["2023-12-28", "2023-12-29"]:
+        assert pd.Timestamp(date, tz="Europe/Zurich") in good_dates
+
+    # 2018-12-31 is a Monday, so New Year's Eve is observed as usual
+    good_dates = six.valid_days("2018-12-01", "2018-12-31", tz="Europe/Zurich")
+    assert pd.Timestamp("2018-12-31", tz="Europe/Zurich") not in good_dates


### PR DESCRIPTION
`NewYearsEve` at `calendars/six.py:25-30` is the only rule in the SIX table carrying a weekend-shifting observance:

```python
NewYearsEve = Holiday("New Year's Eve", month=12, day=31, observance=previous_friday)
```

Every sibling (`NewYearsDay`, `BertholdsDay`, `MayBank`, `SwissNationalDay`, `Christmas`) instead uses `days_of_week=(MONDAY..FRIDAY)` — if the date lands on a weekend, no holiday is observed. So whenever 31 Dec is a Saturday or Sunday, `previous_friday` closes a Friday the exchange actually traded. Measured on `dev`, that is 12 phantom closures between 1995 and 2035: 1995-12-29, 2000-12-29, 2005-12-30, 2006-12-29, 2011-12-30, 2016-12-30, 2017-12-29, 2022-12-30, 2023-12-29, 2028-12-29, 2033-12-30, 2034-12-29.

**This was already decided in this repo.** PR #101 (closing #100) removed `observance=previous_friday` from `ChristmasEve` and deleted the `WeekendChristmas`/`WeekendBoxingDay` substitutes, on the finding that SIX does not shift holidays onto adjacent weekdays. `NewYearsEve` was 51 lines away in the same file and kept it. The test file states the rule twice in its own comments — *"new years (observed): on a weekend, not rolled forward"*.

**Evidence the Fridays were trading days:**
- `exchange_calendars` XSWX (independent implementation, bare `new_years_eve()` with no observance) reports all six of 2005-12-30, 2011-12-30, 2016-12-30, 2017-12-29, 2022-12-30, 2023-12-29 as sessions; this library reports all six closed.
- SIX's own [Key Figures 2022 release](https://www.six-group.com/en/newsroom/media-releases/2023/20230103-keyfigures-six-swiss-exchange-2022.html): *"At the end of 2022, the SMI stood at 10,729.4 points."* The only SMI daily close equal to 10,729.4 is **2022-12-30** — so SIX itself puts the final 2022 session on a day this calendar marks closed.

**Why the tests never caught it:** `test_christmas_weekend` (2016) and `test_eve_day_weekend` (2017) are the only tests covering years where 31 Dec is a weekend, and the phantom date falls *inside each test's own date range* — 2016-12-30 and 2017-12-29 — but neither asserts it. The other two December tests are years where `previous_friday` is a no-op.

**Change:** `days_of_week=(MONDAY..FRIDAY)` to match the siblings, drop the now-unused import, and add `test_new_years_eve_weekend` covering 31 Dec on a Saturday (2022), a Sunday (2023) and a weekday (2018).

**Measured**, same command and venv, `pytest tests -q`:
- before, unmodified `dev` `a3b3990`: 1 failed, 1490 passed
- after: 1 failed, 1491 passed

The one failure is `test_nyse_calendar.py::test_valid_days_tz_aware`, pre-existing on clean `dev` and unrelated (a pandas datetime dtype assertion).

Two mutants confirm the new test is not vacuous: restoring `previous_friday` fails it on 2022-12-30; deleting the `NewYearsEve` rule outright instead fails both it and the existing `test_2018_holidays` on 2018-12-31, so the weekday observance is still load-bearing.

Not from real usage of this library; found reading exchange-calendar tables for observance rules that differ from their siblings' for no stated reason.

**Not tested / disclosed:** I did not verify the pre-1995 dates against a published SIX calendar. `black --check` flags `six.py`, but identically on unmodified `dev` (a blank line after the imports, a black-version difference) — my edit is not the cause and I left it alone rather than adding unrelated churn. Targeted `dev` per CONTRIBUTING.

This was written with AI assistance (Claude).