### PR TITLE
Update TASE calendar for Mon-Fri trading week

### DIFF
--- a/.github/plans/issue_484_tase_monday_friday_trading_week.md
+++ b/.github/plans/issue_484_tase_monday_friday_trading_week.md
@@ -1,0 +1,27 @@
+# Issue 484 TASE Monday-Friday Trading Week Plan
+
+## Current Step
+
+5. Run the TASE tests, the full fast suite, and the formatter checks. Completed.
+
+## Plan
+
+1. Confirm the trading week change (Sunday-Thursday to Monday-Friday effective 2026-01-05, last Sunday session 2026-01-04) and the 2026 closure dates against the exchange schedule, and cross-check both against the upstream `exchange_calendars` XTAE calendar. Completed.
+2. Change the weekmask to Monday-Friday and handle the crossover in `valid_days`, following the NYSE pre/post-1952 Saturday pattern so pre-2026 schedules are unchanged. Completed.
+3. Add the 2026 and 2027 closures to `TASEClosedDay` (the list ended at 2025-10-14). Completed.
+4. Add the Friday 13:34 early close through `special_closes` with the weekday form. Completed.
+5. Add native TASE tests (`tests/test_tase_calendar.py`), run the full fast suite, and run ruff format and check. Completed.
+
+## Assumptions
+
+- The exchange's published schedule is authoritative: Monday-Friday trading from 2026-01-05, Friday sessions 9:59-13:34, and a Friday before a Sunday holiday or holiday eve is closed.
+- The 2027 closures follow the same rules; election days or other one-off closures are added when announced.
+- The regular Monday-Thursday close time (15:59) is left as is; it predates this change and is noted in the issue.
+
+## Validation
+
+- `tests/test_tase_calendar.py`: 6 passed.
+- Full fast suite on the `dev` base: 1497 passed.
+- 2026-2027 session sets identical to the upstream `exchange_calendars` XTAE calendar (492 sessions each, no differences).
+- 2019-2025 schedule output hash-identical to the unmodified branch.
+- Ruff format and check passed for the changed Python files.

--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Unreleased
+~~~~~~~~~~
+- Update TASE calendar for the Monday-Friday trading week effective 2026-01-05
+  - change the weekmask from Sun-Thu to Mon-Fri with the crossover handled in ``valid_days`` (last Sunday session 2026-01-04), following the NYSE pre/post-1952 pattern
+  - add the 2026 and 2027 holiday closures (the previous list ended in 2025, so all 2026 holidays were treated as trading days)
+  - add the Friday early close at 13:34 Asia/Jerusalem
+  - add native TASE calendar tests (``tests/test_tase_calendar.py``)
+
 5.4.0 (05/25/2026)
 ~~~~~~~~~~~~~~~~~~
 - PR #462 to fix numerous issues

--- a/pandas_market_calendars/calendars/tase.py
+++ b/pandas_market_calendars/calendars/tase.py
@@ -1,11 +1,12 @@
 from datetime import time
 from typing import Any, List, Literal, Union
 
-from pandas import DatetimeIndex, Timedelta, Timestamp
+from pandas import DatetimeIndex, Timedelta, Timestamp, date_range
+from pandas.tseries.offsets import CustomBusinessDay
 from zoneinfo import ZoneInfo
 
 from pandas_market_calendars.calendar_utils import Day_Anchor, Month_Anchor
-from pandas_market_calendars.market_calendar import MarketCalendar
+from pandas_market_calendars.market_calendar import FRIDAY, MarketCalendar
 
 
 TASEClosedDay = [
@@ -137,6 +138,38 @@ TASEClosedDay = [
     Timestamp("2025-10-07", tz="Asia/Jerusalem"),
     Timestamp("2025-10-13", tz="Asia/Jerusalem"),
     Timestamp("2025-10-14", tz="Asia/Jerusalem"),
+    # 2026 (Monday-Friday trading week from 2026-01-05)
+    Timestamp("2026-03-03", tz="Asia/Jerusalem"),
+    Timestamp("2026-04-01", tz="Asia/Jerusalem"),
+    Timestamp("2026-04-02", tz="Asia/Jerusalem"),
+    Timestamp("2026-04-07", tz="Asia/Jerusalem"),
+    Timestamp("2026-04-08", tz="Asia/Jerusalem"),
+    Timestamp("2026-04-21", tz="Asia/Jerusalem"),
+    Timestamp("2026-04-22", tz="Asia/Jerusalem"),
+    Timestamp("2026-05-21", tz="Asia/Jerusalem"),
+    Timestamp("2026-05-22", tz="Asia/Jerusalem"),
+    Timestamp("2026-07-23", tz="Asia/Jerusalem"),
+    Timestamp("2026-09-11", tz="Asia/Jerusalem"),
+    Timestamp("2026-09-18", tz="Asia/Jerusalem"),
+    Timestamp("2026-09-21", tz="Asia/Jerusalem"),
+    Timestamp("2026-09-25", tz="Asia/Jerusalem"),
+    Timestamp("2026-10-02", tz="Asia/Jerusalem"),
+    # 2027
+    Timestamp("2027-03-23", tz="Asia/Jerusalem"),
+    Timestamp("2027-04-21", tz="Asia/Jerusalem"),
+    Timestamp("2027-04-22", tz="Asia/Jerusalem"),
+    Timestamp("2027-04-27", tz="Asia/Jerusalem"),
+    Timestamp("2027-04-28", tz="Asia/Jerusalem"),
+    Timestamp("2027-05-11", tz="Asia/Jerusalem"),
+    Timestamp("2027-05-12", tz="Asia/Jerusalem"),
+    Timestamp("2027-06-10", tz="Asia/Jerusalem"),
+    Timestamp("2027-06-11", tz="Asia/Jerusalem"),
+    Timestamp("2027-08-12", tz="Asia/Jerusalem"),
+    Timestamp("2027-10-01", tz="Asia/Jerusalem"),
+    Timestamp("2027-10-08", tz="Asia/Jerusalem"),
+    Timestamp("2027-10-11", tz="Asia/Jerusalem"),
+    Timestamp("2027-10-15", tz="Asia/Jerusalem"),
+    Timestamp("2027-10-22", tz="Asia/Jerusalem"),
 ]
 
 
@@ -144,7 +177,12 @@ class TASEExchangeCalendar(MarketCalendar):
     """
     Exchange calendar for TASE Stock Exchange
 
-    Note these dates are only checked against 2020 and 2021
+    TASE moved from a Sunday-Thursday to a Monday-Friday trading week effective
+    2026-01-05; the last Sunday session was 2026-01-04. Friday sessions close
+    early, ahead of Shabbat.
+    https://www.tase.co.il/en/content/knowledge_center/trading_vacation_schedule/
+
+    Note the dates before 2026 are only checked against 2020 and 2021
     https://info.tase.co.il/Eng/about_tase/corporate/Pages/vacation_schedule.aspx
 
     Opening times for the regular trading of equities (not including closing auction call)
@@ -183,6 +221,10 @@ class TASEExchangeCalendar(MarketCalendar):
         "market_close": ((None, time(15, 59)),),
     }
 
+    # Last session of the Sunday-Thursday trading week; Monday-Friday trading
+    # started 2026-01-05
+    _sunday_end = Timestamp("2026-01-04", tz="UTC")
+
     @property
     def name(self) -> str:
         return "TASE"
@@ -201,7 +243,81 @@ class TASEExchangeCalendar(MarketCalendar):
 
     @property
     def weekmask(self) -> str:
+        return "Mon Tue Wed Thu Fri"
+
+    @property
+    def weekmask_pre_2026(self) -> str:
         return "Sun Mon Tue Wed Thu"
+
+    def holidays_pre_2026(self) -> CustomBusinessDay:
+        """
+        TASE traded Sunday-Thursday before the move to a Monday-Friday trading
+        week effective 2026-01-05 (the last Sunday session was 2026-01-04).
+        CustomBusinessDay object that can be used in place of holidays() for
+        dates prior to the crossover.
+
+        :return: CustomBusinessDay object of holidays
+        """
+        if hasattr(self, "_holidays_pre_2026"):
+            return self._holidays_pre_2026
+
+        self._holidays_pre_2026 = CustomBusinessDay(
+            holidays=self.adhoc_holidays,
+            weekmask=self.weekmask_pre_2026,
+        )
+        return self._holidays_pre_2026
+
+    @property
+    def special_closes(self) -> List[Any]:
+        # Friday sessions (from 2026-01-05) end at 13:34, before Shabbat
+        return [(time(13, 34), FRIDAY)]
+
+    def valid_days(self, start_date: Any, end_date: Any, tz: Any = "UTC") -> DatetimeIndex:
+        """
+        Get a DatetimeIndex of valid open business days.
+
+        Handles the trading week change from Sunday-Thursday to Monday-Friday
+        effective 2026-01-05.
+
+        :param start_date: start date
+        :param end_date: end date
+        :param tz: time zone in either string or pytz.timezone
+        :return: DatetimeIndex of valid business days
+        """
+        start_date = Timestamp(start_date)
+        end_date = Timestamp(end_date)
+        start_date = start_date.tz_convert(tz) if start_date.tz else start_date.tz_localize(tz)
+        end_date = end_date.tz_convert(tz) if end_date.tz else end_date.tz_localize(tz)
+
+        if tz is None:
+            sunday_end = self._sunday_end.tz_localize(None)
+        else:
+            sunday_end = self._sunday_end
+
+        # Entirely within the Monday-Friday trading week. Call super.
+        if start_date > sunday_end:
+            return super().valid_days(start_date, end_date, tz=tz)
+
+        # Entirely within the Sunday-Thursday trading week. Augment the super call.
+        if end_date <= sunday_end:
+            return date_range(
+                start_date,
+                end_date,
+                freq=self.holidays_pre_2026(),
+                normalize=True,
+                tz=tz,
+            )
+
+        # Range is split across the crossover. Concatenate two date_range calls.
+        days_pre = date_range(
+            start_date,
+            sunday_end,
+            freq=self.holidays_pre_2026(),
+            normalize=True,
+            tz=tz,
+        )
+        days_post = date_range(sunday_end, end_date, freq=self.holidays(), normalize=True, tz=tz)
+        return days_pre.union(days_post)
 
     def date_range_htf(
         self,

--- a/tests/test_tase_calendar.py
+++ b/tests/test_tase_calendar.py
@@ -1,0 +1,144 @@
+import pandas as pd
+from pandas.testing import assert_index_equal, assert_series_equal
+
+import pandas_market_calendars as mcal
+
+
+def test_tase_pre_2026_week_is_sunday_to_thursday():
+    actual = mcal.get_calendar("TASE").schedule("2025-06-01", "2025-06-12").index
+
+    expected = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2025-06-03"),  # Tue (Jun 1-2 closed for Shavuot)
+            pd.Timestamp("2025-06-04"),
+            pd.Timestamp("2025-06-05"),
+            pd.Timestamp("2025-06-08"),  # Sun
+            pd.Timestamp("2025-06-09"),
+            pd.Timestamp("2025-06-10"),
+            pd.Timestamp("2025-06-11"),
+            pd.Timestamp("2025-06-12"),
+        ]
+    )
+
+    assert_index_equal(actual, expected)
+
+
+def test_tase_trading_week_transition():
+    # Last Sunday session was 2026-01-04; Monday-Friday trading from 2026-01-05
+    actual = mcal.get_calendar("TASE").schedule("2025-12-28", "2026-01-12").index
+
+    expected = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2025-12-28"),  # Sun
+            pd.Timestamp("2025-12-29"),
+            pd.Timestamp("2025-12-30"),
+            pd.Timestamp("2025-12-31"),
+            pd.Timestamp("2026-01-01"),  # Thu
+            pd.Timestamp("2026-01-04"),  # Sun, last Sunday session
+            pd.Timestamp("2026-01-05"),  # Mon, first Monday-Friday week
+            pd.Timestamp("2026-01-06"),
+            pd.Timestamp("2026-01-07"),
+            pd.Timestamp("2026-01-08"),
+            pd.Timestamp("2026-01-09"),  # Fri, first Friday session
+            pd.Timestamp("2026-01-12"),  # Mon (no Sunday session on Jan 11)
+        ]
+    )
+
+    assert_index_equal(actual, expected)
+
+
+def test_tase_friday_early_close():
+    actual = mcal.get_calendar("TASE").schedule("2026-01-05", "2026-01-09")
+
+    expected = pd.Series(
+        index=[
+            pd.Timestamp("2026-01-05"),
+            pd.Timestamp("2026-01-06"),
+            pd.Timestamp("2026-01-07"),
+            pd.Timestamp("2026-01-08"),
+            pd.Timestamp("2026-01-09"),
+        ],
+        data=[
+            pd.Timestamp("2026-01-05 13:59:00+00:00"),
+            pd.Timestamp("2026-01-06 13:59:00+00:00"),
+            pd.Timestamp("2026-01-07 13:59:00+00:00"),
+            pd.Timestamp("2026-01-08 13:59:00+00:00"),
+            pd.Timestamp("2026-01-09 11:34:00+00:00"),  # 13:34 Asia/Jerusalem
+        ],
+        name="market_close",
+    )
+
+    assert_series_equal(actual["market_close"], expected)
+
+
+def test_tase_2026_high_holidays():
+    # Rosh Hashanah eve (Fri Sep 11), Fri Sep 18 before Yom Kippur eve on
+    # Sunday, Yom Kippur (Mon Sep 21), Sukkot eve (Fri Sep 25)
+    actual = mcal.get_calendar("TASE").schedule("2026-09-07", "2026-09-28").index
+
+    expected = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2026-09-07"),
+            pd.Timestamp("2026-09-08"),
+            pd.Timestamp("2026-09-09"),
+            pd.Timestamp("2026-09-10"),
+            pd.Timestamp("2026-09-14"),
+            pd.Timestamp("2026-09-15"),
+            pd.Timestamp("2026-09-16"),
+            pd.Timestamp("2026-09-17"),
+            pd.Timestamp("2026-09-22"),
+            pd.Timestamp("2026-09-23"),
+            pd.Timestamp("2026-09-24"),
+            pd.Timestamp("2026-09-28"),
+        ]
+    )
+
+    assert_index_equal(actual, expected)
+
+
+def test_tase_2026_passover():
+    # Passover eve/first day (Apr 1-2), seventh day eve/day (Apr 7-8)
+    actual = mcal.get_calendar("TASE").schedule("2026-03-30", "2026-04-10").index
+
+    expected = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2026-03-30"),
+            pd.Timestamp("2026-03-31"),
+            pd.Timestamp("2026-04-03"),  # Fri, Passover interim day
+            pd.Timestamp("2026-04-06"),
+            pd.Timestamp("2026-04-09"),
+            pd.Timestamp("2026-04-10"),
+        ]
+    )
+
+    assert_index_equal(actual, expected)
+
+
+def test_tase_2027_high_holidays():
+    # Rosh Hashanah eve (Fri Oct 1), Fri Oct 8 before Yom Kippur eve on Sunday,
+    # Yom Kippur (Mon Oct 11), Sukkot eve (Fri Oct 15), Simchat Torah eve
+    # (Fri Oct 22)
+    actual = mcal.get_calendar("TASE").schedule("2027-09-27", "2027-10-25").index
+
+    expected = pd.DatetimeIndex(
+        [
+            pd.Timestamp("2027-09-27"),
+            pd.Timestamp("2027-09-28"),
+            pd.Timestamp("2027-09-29"),
+            pd.Timestamp("2027-09-30"),
+            pd.Timestamp("2027-10-04"),
+            pd.Timestamp("2027-10-05"),
+            pd.Timestamp("2027-10-06"),
+            pd.Timestamp("2027-10-07"),
+            pd.Timestamp("2027-10-12"),
+            pd.Timestamp("2027-10-13"),
+            pd.Timestamp("2027-10-14"),
+            pd.Timestamp("2027-10-18"),
+            pd.Timestamp("2027-10-19"),
+            pd.Timestamp("2027-10-20"),
+            pd.Timestamp("2027-10-21"),
+            pd.Timestamp("2027-10-25"),
+        ]
+    )
+
+    assert_index_equal(actual, expected)


### PR DESCRIPTION
Fixes #484

Updates the TASE calendar for the exchange's move from a Sunday-Thursday to a Monday-Friday trading week, effective 2026-01-05 (last Sunday session 2026-01-04, first Friday session 2026-01-09), and adds the missing 2026 and 2027 holiday closures. The previous `TASEClosedDay` list ended at 2025-10-14, so every 2026 holiday was being reported as a trading day, and the old weekmask reported every Sunday since January as open and every Friday as closed.

Three changes in `calendars/tase.py`:

- The weekmask becomes `"Mon Tue Wed Thu Fri"`, with the crossover handled in an overridden `valid_days` that stitches a pre-2026 `CustomBusinessDay` (old weekmask) to the regular path, following the exact pattern `NYSEExchangeCalendar.valid_days` uses for the 1952 Saturday crossover. Pre-2026 output is unchanged: the 2019-2025 schedule hashes identically before and after this change.
- `TASEClosedDay` gains the 2026 and 2027 closures. The 2026 dates match the exchange's published schedule, including the new-trading-week rule that a Friday before a Sunday holiday or holiday eve is closed (e.g. Friday 2026-09-18 ahead of Yom Kippur eve on Sunday 2026-09-20). The 2027 dates follow the same rules; election days or other one-off closures would still need to be added when announced.
- Friday sessions get a 13:34 Asia/Jerusalem early close via `special_closes` with the weekday form, per the exchange's published Friday hours (9:59-13:34). This uses the continuous-session end, consistent with the calendar's documented convention of excluding the closing auction. Pre-2026 Fridays are unaffected since they are not valid days.

Validation:

- New tests in `tests/test_tase_calendar.py` (the existing `test_xtae_calendar.py` covers the mirrored calendar, not this one): transition week, both regimes, 2026 Passover and High Holidays, 2027 High Holidays, and the Friday close. Full suite passes: 1495 tests.
- Cross-checked against the upstream `exchange_calendars` XTAE calendar, which models the transition independently (holiday dates computed from the Hebrew calendar via pyluach): the session sets for 2026-2027 are identical, 492 sessions each, zero differences.
- 2019-2025 schedule output is byte-identical to master (hash-compared), so no historical behavior changes.
- `ruff format --check` and `ruff check` pass on the changed files.

The change log has an entry under Unreleased. Noted but deliberately not touched, since they predate this change: the regular Mon-Thu close is still 15:59 (TASE's continuous session currently ends 17:14; the docstring already flags the times as only checked against 2020-2021), the old-regime Sunday early close was never modeled, and `date_range_htf` anchoring for pre-2026 ranges still uses the current weekmask (NYSE handles the equivalent with a larger `date_range_htf` override; happy to follow up if wanted).
